### PR TITLE
Test EcdsaKoblitzSignature2016 with security context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 v8.log
 .c9revisions
 npm-debug.log
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - 4
-  - 5
-  - 6
+  - "4"
+  - "5"
+  - "6"
+  - "7"
   - "node"
   - "iojs"
 sudo: false
 # download test suite and run tests... submodule? meta testing project with
 # all of the reference implementations?
 script:
-  - npm run test
+  - npm run test-all
 notifications:
   email:
     on_success: change

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -298,7 +298,7 @@ api.verify = function(input, options, callback) {
       return callback(new Error('[jsigs.verify] No signature found.'));
     }
     var algorithm = jsonld.getValues(signature, 'type')[0] || '';
-    // algorithm = algorithm.replace(/^.+:/, '')  // strip off any namespace to compare to known algorithm names
+    algorithm = algorithm.replace(/^.+:/, '');  // strip off any namespace to compare to known algorithm names
     if(api.SUPPORTED_ALGORITHMS.indexOf(algorithm) === -1) {
       return callback(new Error(
         '[jsigs.verify] Unsupported signature algorithm "' + algorithm + '"; ' +

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -144,7 +144,8 @@ api.sign = function(input, options, callback) {
 
   if(api.SUPPORTED_ALGORITHMS.indexOf(algorithm) === -1) {
     return callback(new Error(
-      '[jsig.sign] options.algorithm must be one of: ' +
+      '[jsigs.sign] Unsupported algorithm "' + algorithm + '"; ' +
+      'options.algorithm must be one of: ' +
       JSON.stringify(api.SUPPORTED_ALGORITHMS)));
   }
 
@@ -299,8 +300,9 @@ api.verify = function(input, options, callback) {
     var algorithm = jsonld.getValues(signature, 'type')[0] || '';
     if(api.SUPPORTED_ALGORITHMS.indexOf(algorithm) === -1) {
       return callback(new Error(
-        '[jsigs.verify] Unsupported signature algorithm; supported ' +
-        'algorithms are: ' + JSON.stringify(api.SUPPORTED_ALGORITHMS)));
+        '[jsigs.verify] Unsupported signature algorithm "' + algorithm + '"; ' +
+        'supported algorithms are: ' +
+        JSON.stringify(api.SUPPORTED_ALGORITHMS)));
     }
     return _verify(algorithm, input, options, callback);
   });

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -741,10 +741,14 @@ var _verifySignature = function(input, signature, options, callback) {
 
   if(options.algorithm === 'EcdsaKoblitzSignature2016') {
     // works same in any environment
-    var bitcoreMessage = api.use('bitcoreMessage');
-    var message = bitcoreMessage(_getDataToHash(input, options));
-    verified = message.verify(options.publicKeyWif, signature);
-    return callback(null, verified);
+    try {
+      var bitcoreMessage = api.use('bitcoreMessage');
+      var message = bitcoreMessage(_getDataToHash(input, options));
+      verified = message.verify(options.publicKeyWif, signature);
+      return callback(null, verified);
+    } catch (err) {
+      return callback(err);
+    }
   }
 
   if(_nodejs) {

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -298,6 +298,7 @@ api.verify = function(input, options, callback) {
       return callback(new Error('[jsigs.verify] No signature found.'));
     }
     var algorithm = jsonld.getValues(signature, 'type')[0] || '';
+    // algorithm = algorithm.replace(/^.+:/, '')  // strip off any namespace to compare to known algorithm names
     if(api.SUPPORTED_ALGORITHMS.indexOf(algorithm) === -1) {
       return callback(new Error(
         '[jsigs.verify] Unsupported signature algorithm "' + algorithm + '"; ' +

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -678,13 +678,14 @@ function _verify(algorithm, input, options, callback) {
  * @param callback(err, signature) called once the operation completes.
  */
 var _createSignature = function(input, options, callback) {
+  var signature, privateKey;
+
   if(options.algorithm === 'EcdsaKoblitzSignature2016') {
     // works same in any environment
-    var signature;
     try {
       var bitcoreMessage = api.use('bitcoreMessage');
       var bitcore = bitcoreMessage.Bitcore;
-      var privateKey = bitcore.PrivateKey.fromWIF(options.privateKeyWif);
+      privateKey = bitcore.PrivateKey.fromWIF(options.privateKeyWif);
       var message = bitcoreMessage(_getDataToHash(input, options));
       signature = message.sign(privateKey);
     } catch(err) {
@@ -695,7 +696,6 @@ var _createSignature = function(input, options, callback) {
 
   if(_nodejs) {
     // optimize using node libraries
-    var signature;
     try {
       var crypto = api.use('crypto');
       var signer = crypto.createSign('RSA-SHA256');
@@ -708,10 +708,9 @@ var _createSignature = function(input, options, callback) {
   }
 
   // browser or other environment
-  var signature;
   try {
     var forge = api.use('forge');
-    var privateKey = forge.pki.privateKeyFromPem(options.privateKeyPem);
+    privateKey = forge.pki.privateKeyFromPem(options.privateKeyPem);
     var md = forge.md.sha256.create();
     md.update(_getDataToHash(input, options), 'utf8');
     signature = forge.util.encode64(privateKey.sign(md));
@@ -736,11 +735,13 @@ var _createSignature = function(input, options, callback) {
  * @param callback(err, valid) called once the operation completes.
  */
 var _verifySignature = function(input, signature, options, callback) {
+  var verified;
+
   if(options.algorithm === 'EcdsaKoblitzSignature2016') {
     // works same in any environment
     var bitcoreMessage = api.use('bitcoreMessage');
     var message = bitcoreMessage(_getDataToHash(input, options));
-    var verified = message.verify(options.publicKeyWif, signature);
+    verified = message.verify(options.publicKeyWif, signature);
     return callback(null, verified);
   }
 
@@ -749,7 +750,7 @@ var _verifySignature = function(input, signature, options, callback) {
     var crypto = api.use('crypto');
     var verifier = crypto.createVerify('RSA-SHA256');
     verifier.update(_getDataToHash(input, options), 'utf8');
-    var verified = verifier.verify(options.publicKeyPem, signature, 'base64');
+    verified = verifier.verify(options.publicKeyPem, signature, 'base64');
     return callback(null, verified);
   }
 
@@ -758,7 +759,7 @@ var _verifySignature = function(input, signature, options, callback) {
   var publicKey = forge.pki.publicKeyFromPem(options.publicKeyPem);
   var md = forge.md.sha256.create();
   md.update(_getDataToHash(input, options), 'utf8');
-  var verified = publicKey.verify(
+  verified = publicKey.verify(
     md.digest().bytes(), forge.util.decode64(signature));
   callback(null, verified);
 };

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "istanbul": "~0.4.5",
     "mocha": "^2.3.2",
     "mocha-phantomjs": "~3.5.0",
+    "npm-run-all": "^3.1.1",
     "phantomjs": "~1.9.20"
   },
   "engines": {
@@ -71,6 +72,7 @@
     "ci-lint": "grunt jshint --mode=ci || exit 0",
     "lint": "grunt jshint",
     "jscs": "grunt jscs",
+    "test-all": "npm-run-all --silent test lint jscs",
     "test-node": "grunt mochaTest",
     "test-browser": "grunt shell:testBrowser",
     "test": "grunt mochaTest shell:testBrowser",

--- a/package.json
+++ b/package.json
@@ -33,20 +33,20 @@
   "license": "BSD-3-Clause",
   "main": "lib/jsonld-signatures.js",
   "dependencies": {
-    "async": "^1.4.2",
+    "async": "^1.5.2",
     "bitcore-message": "github:CoMakery/bitcore-message#dist",
     "commander": "~2.9.0",
-    "es6-promise": "~3.3.1",
+    "es6-promise": "~4.0.5",
     "jsonld": "0.4.3",
-    "node-forge": "~0.6.42"
+    "node-forge": "~0.6.45"
   },
   "devDependencies": {
     "chai": "^3.5.0",
     "grunt": "~1.0.1",
     "grunt-cli": "~1.2.0",
-    "grunt-contrib-jshint": "~1.0.0",
+    "grunt-contrib-jshint": "~1.1.0",
     "grunt-jscs": "^3.0.1",
-    "grunt-mocha-test": "~0.12.4",
+    "grunt-mocha-test": "~0.13.2",
     "grunt-release": "~0.14.0",
     "grunt-shell": "~1.3.1",
     "istanbul": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -38,8 +38,7 @@
     "commander": "~2.9.0",
     "es6-promise": "~3.3.1",
     "jsonld": "0.4.3",
-    "node-forge": "~0.6.42",
-    "underscore": "~1.8.3"
+    "node-forge": "~0.6.42"
   },
   "devDependencies": {
     "chai": "^3.5.0",
@@ -69,7 +68,6 @@
     "digital signatures"
   ],
   "scripts": {
-    "ci-lint": "grunt jshint --mode=ci || exit 0",
     "lint": "grunt jshint",
     "jscs": "grunt jscs",
     "test-all": "npm-run-all --silent test lint jscs",

--- a/tests/bind.js
+++ b/tests/bind.js
@@ -17,9 +17,7 @@ if (!Function.prototype.bind) {
         fToBind = this,
         fNOP    = function() {},
         fBound  = function() {
-          return fToBind.apply(this instanceof fNOP
-                 ? this
-                 : oThis,
+          return fToBind.apply(this instanceof fNOP ? this : oThis,
                  aArgs.concat(Array.prototype.slice.call(arguments)));
         };
 

--- a/tests/test.js
+++ b/tests/test.js
@@ -16,6 +16,12 @@ var _nodejs = (typeof process !== 'undefined' &&
 
 var _jsdir, jsonld, jsigs, assert, program;
 
+// temporary, until EcdsaKoblitzSignature2016 is added to
+// default security context.
+// see also: https://github.com/web-payments/web-payments.org/issues/41
+var NEAR_FUTURE_SECURITY_CONTEXT =
+  "https://comakery.github.io/json-ld.org/schemas/security-v1-patch.jsonld";
+
 if(_nodejs) {
   _jsdir = process.env.JSDIR || 'lib';
   jsonld = require('../node_modules/jsonld');
@@ -47,7 +53,8 @@ if(_nodejs) {
   // PhantomJS is really bad at doing XHRs, so we have to fake the network
   // fetch of the JSON-LD Contexts
   var contextLoader = function(url, callback) {
-    if(url === 'https://w3id.org/security/v1') {
+    if(url === 'https://w3id.org/security/v1' ||
+      url === NEAR_FUTURE_SECURITY_CONTEXT) {
       callback(null, {
         contextUrl: null,
         document: securityContext,
@@ -118,7 +125,7 @@ describe('JSON-LD Signatures', function() {
     publicKey: [testPublicKey]
   };
 
-  describe('signing and verify Graph2012 w/o security context', function() {
+  context('with NO security context', function() {
     // the test document that will be signed
     var testDocument = {
       '@context': {
@@ -133,293 +140,283 @@ describe('JSON-LD Signatures', function() {
     };
     var testDocumentSigned = {};
 
-    it('should successfully sign a local document', function(done) {
-      jsigs.sign(testDocument, {
-        algorithm: 'GraphSignature2012',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }, function(err, signedDocument) {
-        assert.ifError(err);
-        assert.notEqual(
-          signedDocument['https://w3id.org/security#signature'], undefined,
-          'signature was not created');
-        assert.equal(
-          signedDocument['https://w3id.org/security#signature']
-            ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-        done();
+    describe('signing and verify Graph2012', function() {
+      it('should successfully sign a local document', function(done) {
+        jsigs.sign(testDocument, {
+          algorithm: 'GraphSignature2012',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }, function(err, signedDocument) {
+          assert.ifError(err);
+          assert.notEqual(
+            signedDocument['https://w3id.org/security#signature'], undefined,
+            'signature was not created');
+          assert.equal(
+            signedDocument['https://w3id.org/security#signature']
+              ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+          done();
+        });
       });
-    });
 
-    it('should successfully verify a local signed document', function(done) {
-      jsigs.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }, function(err, verified) {
-        assert.ifError(err);
-        assert.equal(verified, true, 'signature verification failed');
-        done();
+      it('should successfully verify a local signed document', function(done) {
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, true, 'signature verification failed');
+          done();
+        });
       });
-    });
 
-    it('should successfully sign a local document w/promises API', function(done) {
-      jsigs.promises.sign(testDocument, {
-        algorithm: 'GraphSignature2012',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }).then(function(signedDocument) {
-        assert.notEqual(
-          signedDocument['https://w3id.org/security#signature'], undefined,
-          'signature was not created');
-        assert.equal(
-          signedDocument['https://w3id.org/security#signature']
-            ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully sign a local document w/promises API', function(done) {
+        jsigs.promises.sign(testDocument, {
+          algorithm: 'GraphSignature2012',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }).then(function(signedDocument) {
+          assert.notEqual(
+            signedDocument['https://w3id.org/security#signature'], undefined,
+            'signature was not created');
+          assert.equal(
+            signedDocument['https://w3id.org/security#signature']
+              ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
       });
-    });
 
-    it('should successfully verify a local signed document w/promises API', function(done) {
-      jsigs.promises.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }).then(function(verified) {
-        assert.equal(verified, true, 'signature verification failed');
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully verify a local signed document w/promises API', function(done) {
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }).then(function(verified) {
+          assert.equal(verified, true, 'signature verification failed');
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
       });
+
     });
 
-  });
-
-  describe('signing and verify Graph2015 w/o security context', function() {
-    // the test document that will be signed
-    var testDocument = {
-      '@context': {
-        schema: 'http://schema.org/',
-        name: 'schema:name',
-        homepage: 'schema:url',
-        image: 'schema:image'
-      },
-      name: 'Manu Sporny',
-      homepage: 'https://manu.sporny.org/',
-      image: 'https://manu.sporny.org/images/manu.png'
-    };
-    var testDocumentSigned = {};
-
-    it('should successfully sign a local document', function(done) {
-      jsigs.sign(testDocument, {
-        algorithm: 'LinkedDataSignature2015',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }, function(err, signedDocument) {
-        assert.ifError(err);
-        assert.notEqual(
-          signedDocument['https://w3id.org/security#signature'], undefined,
-          'signature was not created');
-        assert.equal(
-          signedDocument['https://w3id.org/security#signature']
-            ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-        done();
+    describe('signing and verify Graph2015', function() {
+      it('should successfully sign a local document', function(done) {
+        jsigs.sign(testDocument, {
+          algorithm: 'LinkedDataSignature2015',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }, function(err, signedDocument) {
+          assert.ifError(err);
+          assert.notEqual(
+            signedDocument['https://w3id.org/security#signature'], undefined,
+            'signature was not created');
+          assert.equal(
+            signedDocument['https://w3id.org/security#signature']
+              ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+          done();
+        });
       });
-    });
 
-    it('should successfully verify a local signed document', function(done) {
-      jsigs.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }, function(err, verified) {
-        assert.ifError(err);
-        assert.equal(verified, true, 'signature verification failed');
-        done();
+      it('should successfully verify a local signed document', function(done) {
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, true, 'signature verification failed');
+          done();
+        });
       });
-    });
 
-    it('should successfully sign a local document w/promises API', function(done) {
-      jsigs.promises.sign(testDocument, {
-        algorithm: 'LinkedDataSignature2015',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }).then(function(signedDocument) {
-        assert.notEqual(
-          signedDocument['https://w3id.org/security#signature'], undefined,
-          'signature was not created');
-        assert.equal(
-          signedDocument['https://w3id.org/security#signature']
-            ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully sign a local document w/promises API', function(done) {
+        jsigs.promises.sign(testDocument, {
+          algorithm: 'LinkedDataSignature2015',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }).then(function(signedDocument) {
+          assert.notEqual(
+            signedDocument['https://w3id.org/security#signature'], undefined,
+            'signature was not created');
+          assert.equal(
+            signedDocument['https://w3id.org/security#signature']
+              ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
       });
-    });
 
-    it('should successfully verify a local signed document w/promises API', function(done) {
-      jsigs.promises.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }).then(function(verified) {
-        assert.equal(verified, true, 'signature verification failed');
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully verify a local signed document w/promises API', function(done) {
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }).then(function(verified) {
+          assert.equal(verified, true, 'signature verification failed');
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
       });
-    });
-  });
-
-  describe('signing and verify EcdsaKoblitzSignature2016 w/o security context', function() {
-    var testDocument;
-    var testDocumentSigned;
-    var testPrivateKeyWif;
-    var testPublicKeyWif;
-    var testPublicKeyFriendly;
-    var testPublicKeyBtc;
-    var testPublicKeyBtcOwner;
-    var invalidPublicKeyWif = '1BHdCBqQ1GQLfHVEnoXtYf44T97aEHodwe';
-
-    beforeEach(function() {
-      testDocument = {
-        '@context': {
-          schema: 'http://schema.org/',
-          name: 'schema:name',
-          homepage: 'schema:url',
-          image: 'schema:image'
-        },
-        name: 'Manu Sporny',
-        homepage: 'https://manu.sporny.org/',
-        image: 'https://manu.sporny.org/images/manu.png'
-      };
-
-      testDocumentSigned = clone(testDocument);
-      testDocumentSigned["https://w3id.org/security#signature"] = {
-        "@type": "EcdsaKoblitzSignature2016",
-        "http://purl.org/dc/terms/created": {
-          "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-          "@value": "2016-11-30T01:44:34Z"
-        },
-        "http://purl.org/dc/terms/creator": {
-          "@id": "ecdsa-koblitz-pubkey:1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER"
-        },
-        "https://w3id.org/security#signatureValue": "IEDwNo/X5cQx0ZQwXx1Qt5kO+gQQ0IPgURC/SpmbRT5lWUC65QByTDkqu6OWKRcZ0EbRZlV/NVUNr+XExxTmECI="
-      };
-
-      testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw';
-      testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER';
-      testPublicKeyFriendly = 'ecdsa-koblitz-pubkey:' + testPublicKeyWif;
-
-      testPublicKeyBtc = {
-        '@context': jsigs.SECURITY_CONTEXT_URL,
-        id: testPublicKeyFriendly,
-        type: 'CryptographicKey',
-        owner: 'https://example.com/i/alice',
-        publicKeyWif: testPublicKeyWif
-      };
-
-      testPublicKeyBtcOwner = {
-        '@context': jsigs.SECURITY_CONTEXT_URL,
-        id: 'https://example.com/i/alice',
-        publicKey: [testPublicKeyFriendly]
-      };
 
     });
 
-    it('should successfully sign a local document', function(done) {
-      jsigs.sign(testDocument, {
-        algorithm: 'EcdsaKoblitzSignature2016',
-        privateKeyWif: testPrivateKeyWif,
-        creator: testPublicKeyFriendly
-      }, function(err, signedDocument) {
-        assert.ifError(err);
-        assert.notEqual(
-          signedDocument['https://w3id.org/security#signature'], undefined,
-          'signature was not created');
-        assert.equal(
-          signedDocument['https://w3id.org/security#signature']
-            ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyFriendly,
-          'creator key for signature is wrong');
-        done();
+    describe('signing and verify EcdsaKoblitzSignature2016', function() {
+
+      var testDocument;
+      var testDocumentSigned;
+      var testPrivateKeyWif;
+      var testPublicKeyWif;
+      var testPublicKeyFriendly;
+      var testPublicKeyBtc;
+      var testPublicKeyBtcOwner;
+      var invalidPublicKeyWif;
+
+      beforeEach(function() {
+        testDocument = {
+          '@context': {
+            schema: 'http://schema.org/',
+            name: 'schema:name',
+            homepage: 'schema:url',
+            image: 'schema:image'
+          },
+          name: 'Manu Sporny',
+          homepage: 'https://manu.sporny.org/',
+          image: 'https://manu.sporny.org/images/manu.png'
+        };
+
+        testDocumentSigned = clone(testDocument);
+        testDocumentSigned["https://w3id.org/security#signature"] = {
+          "@type": "EcdsaKoblitzSignature2016",
+          "http://purl.org/dc/terms/created": {
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+            "@value": "2016-11-30T01:44:34Z"
+          },
+          "http://purl.org/dc/terms/creator": {
+            "@id": "ecdsa-koblitz-pubkey:1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER"
+          },
+          "https://w3id.org/security#signatureValue": "IEDwNo/X5cQx0ZQwXx1Qt5kO+gQQ0IPgURC/SpmbRT5lWUC65QByTDkqu6OWKRcZ0EbRZlV/NVUNr+XExxTmECI="
+        };
+
+        testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw';
+        testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER';
+        testPublicKeyFriendly = 'ecdsa-koblitz-pubkey:' + testPublicKeyWif;
+
+        testPublicKeyBtc = {
+          '@context': jsigs.SECURITY_CONTEXT_URL,
+          id: testPublicKeyFriendly,
+          type: 'CryptographicKey',
+          owner: 'https://example.com/i/alice',
+          publicKeyWif: testPublicKeyWif
+        };
+
+        testPublicKeyBtcOwner = {
+          '@context': jsigs.SECURITY_CONTEXT_URL,
+          id: 'https://example.com/i/alice',
+          publicKey: [testPublicKeyFriendly]
+        };
+
+        invalidPublicKeyWif = '1BHdCBqQ1GQLfHVEnoXtYf44T97aEHodwe';
       });
-    });
 
-    it('should successfully verify a local signed document', function(done) {
-      jsigs.verify(testDocumentSigned, {
-        publicKey: testPublicKeyBtc,
-        publicKeyOwner: testPublicKeyBtcOwner
-      }, function(err, verified) {
-        assert.ifError(err);
-        assert.equal(verified, true, 'signature verification failed');
-        done();
+      it('should successfully sign a local document', function(done) {
+        jsigs.sign(testDocument, {
+          algorithm: 'EcdsaKoblitzSignature2016',
+          privateKeyWif: testPrivateKeyWif,
+          creator: testPublicKeyFriendly
+        }, function(err, signedDocument) {
+          assert.ifError(err);
+          assert.notEqual(
+            signedDocument['https://w3id.org/security#signature'], undefined,
+            'signature was not created');
+          assert.equal(
+            signedDocument['https://w3id.org/security#signature']
+              ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyFriendly,
+            'creator key for signature is wrong');
+          done();
+        });
       });
-    });
 
-    it('verify should return false if the document was signed by a different private key', function(done) {
-      testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
-
-      jsigs.verify(testDocumentSigned, {
-        publicKey: testPublicKeyBtc,
-        publicKeyOwner: testPublicKeyBtcOwner
-      }, function(err, verified) {
-        assert.ifError(err);
-        assert.equal(verified, false, 'signature verification should have failed');
-        done();
+      it('should successfully verify a local signed document', function(done) {
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, true, 'signature verification failed');
+          done();
+        });
       });
-    });
 
-    it('should successfully sign a local document' +
-      ' w/promises API', function(done) {
-      jsigs.promises.sign(testDocument, {
-        algorithm: 'EcdsaKoblitzSignature2016',
-        privateKeyWif: testPrivateKeyWif,
-        creator: testPublicKeyFriendly
-      }).then(function(signedDocument) {
-        assert.notEqual(
-          signedDocument['https://w3id.org/security#signature'], undefined,
-          'signature was not created');
-        assert.equal(
-          signedDocument['https://w3id.org/security#signature']
-            ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyFriendly,
-          'creator key for signature is wrong');
-      }).then(done).catch(done);
-    });
+      it('verify should return false if the document was signed by a different private key', function(done) {
+        testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
 
-    it('should successfully verify a local signed document' +
-      ' w/promises API', function(done) {
-      jsigs.promises.verify(testDocumentSigned, {
-        publicKey: testPublicKeyBtc,
-        publicKeyOwner: testPublicKeyBtcOwner
-      }).then(function(verified) {
-        assert.equal(verified, true, 'signature verification failed');
-      }).then(done).catch(done);
-    });
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, false, 'signature verification should have failed');
+          done();
+        });
+      });
 
-    it('verify should return false if the document was signed by' +
-      ' a different private key w/promises API', function(done) {
-      testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
+      it('should successfully sign a local document' +
+        ' w/promises API', function(done) {
+        jsigs.promises.sign(testDocument, {
+          algorithm: 'EcdsaKoblitzSignature2016',
+          privateKeyWif: testPrivateKeyWif,
+          creator: testPublicKeyFriendly
+        }).then(function(signedDocument) {
+          assert.notEqual(
+            signedDocument['https://w3id.org/security#signature'], undefined,
+            'signature was not created');
+          assert.equal(
+            signedDocument['https://w3id.org/security#signature']
+              ['http://purl.org/dc/terms/creator']['@id'], testPublicKeyFriendly,
+            'creator key for signature is wrong');
+        }).then(done).catch(done);
+      });
 
-      jsigs.promises.verify(testDocumentSigned, {
-        publicKey: testPublicKeyBtc,
-        publicKeyOwner: testPublicKeyBtcOwner
-      }).then(function(verified) {
-        assert.equal(verified, false,
-          'signature verification should have failed but did not');
-      }).then(done).catch(done);
+      it('should successfully verify a local signed document' +
+        ' w/promises API', function(done) {
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }).then(function(verified) {
+          assert.equal(verified, true, 'signature verification failed');
+        }).then(done).catch(done);
+      });
+
+      it('verify should return false if the document was signed by' +
+        ' a different private key w/promises API', function(done) {
+        testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
+
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }).then(function(verified) {
+          assert.equal(verified, false,
+            'signature verification should have failed but did not');
+        }).then(done).catch(done);
+      });
     });
   });
 
-  describe('signing and verify GraphSignature2012 w/security context', function() {
-
+  context('with security context', function() {
     // the test document that will be signed
     var testDocument = {
       '@context': [{
@@ -434,138 +431,262 @@ describe('JSON-LD Signatures', function() {
     };
     var testDocumentSigned = {};
 
-    it('should successfully sign a local document', function(done) {
-      jsigs.sign(testDocument, {
-        algorithm: 'GraphSignature2012',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }, function(err, signedDocument) {
-        assert.ifError(err);
-        assert.notEqual(signedDocument.signature, undefined,
-          'signature was not created');
-        assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-        done();
+    describe('signing and verify GraphSignature2012 w/security context', function() {
+      it('should successfully sign a local document', function(done) {
+        jsigs.sign(testDocument, {
+          algorithm: 'GraphSignature2012',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }, function(err, signedDocument) {
+          assert.ifError(err);
+          assert.notEqual(signedDocument.signature, undefined,
+            'signature was not created');
+          assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+          done();
+        });
+      });
+
+      it('should successfully verify a local signed document', function(done) {
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, true, 'signature verification failed');
+          done();
+        });
+      });
+
+      it('should successfully sign a local document w/promises API', function(done) {
+        jsigs.promises.sign(testDocument, {
+          algorithm: 'GraphSignature2012',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }).then(function(signedDocument) {
+          assert.notEqual(signedDocument.signature, undefined,
+            'signature was not created');
+          assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
+      });
+
+      it('should successfully verify a local signed document w/promises API', function(done) {
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }).then(function(verified) {
+          assert.equal(verified, true, 'signature verification failed');
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
+      });
+
+    });
+
+    describe('signing and verify LinkedDataSignature2015 w/security context', function() {
+      it('should successfully sign a local document', function(done) {
+        jsigs.sign(testDocument, {
+          algorithm: 'LinkedDataSignature2015',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }, function(err, signedDocument) {
+          assert.ifError(err);
+          assert.notEqual(signedDocument.signature, undefined,
+            'signature was not created');
+          assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+          done();
+        });
+      });
+
+      it('should successfully verify a local signed document', function(done) {
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, true, 'signature verification failed');
+          done();
+        });
+      });
+
+      it('should successfully sign a local document w/promises', function(done) {
+        jsigs.promises.sign(testDocument, {
+          algorithm: 'LinkedDataSignature2015',
+          privateKeyPem: testPrivateKeyPem,
+          creator: testPublicKeyUrl
+        }).then(function(signedDocument) {
+          assert.notEqual(signedDocument.signature, undefined,
+            'signature was not created');
+          assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
+      });
+
+      it('should successfully verify a local signed document w/promises', function(done) {
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKey,
+          publicKeyOwner: testPublicKeyOwner
+        }).then(function(verified) {
+          assert.equal(verified, true, 'signature verification failed');
+        }).catch(function(err) {
+          assert.ifError(err);
+        }).then(function() {
+          done();
+        });
       });
     });
 
-    it('should successfully verify a local signed document', function(done) {
-      jsigs.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }, function(err, verified) {
-        assert.ifError(err);
-        assert.equal(verified, true, 'signature verification failed');
-        done();
+    describe('signing and verify EcdsaKoblitzSignature2016', function() {
+      var testDocument;
+      var testDocumentSigned;
+      var testPrivateKeyWif;
+      var testPublicKeyWif;
+      var testPublicKeyFriendly;
+      var testPublicKeyBtc;
+      var testPublicKeyBtcOwner;
+      var invalidPublicKeyWif;
+
+      beforeEach(function() {
+        testDocument = {
+          '@context': [{
+            schema: 'http://schema.org/',
+            name: 'schema:name',
+            homepage: 'schema:url',
+            image: 'schema:image'
+          }, NEAR_FUTURE_SECURITY_CONTEXT],
+          name: 'Manu Sporny',
+          homepage: 'https://manu.sporny.org/',
+          image: 'https://manu.sporny.org/images/manu.png'
+        };
+
+        testDocumentSigned = clone(testDocument);
+        testDocumentSigned["https://w3id.org/security#signature"] = {
+          "@type": "EcdsaKoblitzSignature2016",
+          "http://purl.org/dc/terms/created": {
+            "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
+            "@value": "2016-11-30T01:44:34Z"
+          },
+          "http://purl.org/dc/terms/creator": {
+            "@id": "ecdsa-koblitz-pubkey:1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER"
+          },
+          "https://w3id.org/security#signatureValue": "IEDwNo/X5cQx0ZQwXx1Qt5kO+gQQ0IPgURC/SpmbRT5lWUC65QByTDkqu6OWKRcZ0EbRZlV/NVUNr+XExxTmECI="
+        };
+
+        testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw';
+        testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER';
+        testPublicKeyFriendly = 'ecdsa-koblitz-pubkey:' + testPublicKeyWif;
+
+        testPublicKeyBtc = {
+          '@context': jsigs.SECURITY_CONTEXT_URL,
+          id: testPublicKeyFriendly,
+          type: 'CryptographicKey',
+          owner: 'https://example.com/i/alice',
+          publicKeyWif: testPublicKeyWif
+        };
+
+        testPublicKeyBtcOwner = {
+          '@context': jsigs.SECURITY_CONTEXT_URL,
+          id: 'https://example.com/i/alice',
+          publicKey: [testPublicKeyFriendly]
+        };
+
+        invalidPublicKeyWif = '1BHdCBqQ1GQLfHVEnoXtYf44T97aEHodwe';
       });
-    });
 
-    it('should successfully sign a local document w/promises API', function(done) {
-      jsigs.promises.sign(testDocument, {
-        algorithm: 'GraphSignature2012',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }).then(function(signedDocument) {
-        assert.notEqual(signedDocument.signature, undefined,
-          'signature was not created');
-        assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully sign a local document', function(done) {
+        jsigs.sign(testDocument, {
+          algorithm: 'EcdsaKoblitzSignature2016',
+          privateKeyWif: testPrivateKeyWif,
+          creator: testPublicKeyFriendly
+        }, function(err, signedDocument) {
+          assert.ifError(err);
+          assert.notEqual(
+            signedDocument.signature, undefined, 'signature was not created');
+          assert.equal(
+            signedDocument.signature.creator, testPublicKeyFriendly,
+            'creator key for signature is wrong');
+          done();
+        });
       });
-    });
 
-    it('should successfully verify a local signed document w/promises API', function(done) {
-      jsigs.promises.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }).then(function(verified) {
-        assert.equal(verified, true, 'signature verification failed');
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully verify a local signed document', function(done) {
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, true, 'signature verification failed');
+          done();
+        });
       });
-    });
 
-  });
+      it('verify should return false if the document was signed by a different private key', function(done) {
+        testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
 
-  describe('signing and verify LinkedDataSignature2015 w/security context', function() {
-
-    // the test document that will be signed
-    var testDocument = {
-      '@context': [{
-        schema: 'http://schema.org/',
-        name: 'schema:name',
-        homepage: 'schema:url',
-        image: 'schema:image'
-      }, jsigs.SECURITY_CONTEXT_URL],
-      name: 'Manu Sporny',
-      homepage: 'https://manu.sporny.org/',
-      image: 'https://manu.sporny.org/images/manu.png'
-    };
-    var testDocumentSigned = {};
-
-    it('should successfully sign a local document', function(done) {
-      jsigs.sign(testDocument, {
-        algorithm: 'LinkedDataSignature2015',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }, function(err, signedDocument) {
-        assert.ifError(err);
-        assert.notEqual(signedDocument.signature, undefined,
-          'signature was not created');
-        assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-        done();
+        jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, false, 'signature verification should have failed');
+          done();
+        });
       });
-    });
 
-    it('should successfully verify a local signed document', function(done) {
-      jsigs.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }, function(err, verified) {
-        assert.ifError(err);
-        assert.equal(verified, true, 'signature verification failed');
-        done();
+      it('should successfully sign a local document' +
+        ' w/promises API', function(done) {
+        jsigs.promises.sign(testDocument, {
+          algorithm: 'EcdsaKoblitzSignature2016',
+          privateKeyWif: testPrivateKeyWif,
+          creator: testPublicKeyFriendly
+        }).then(function(signedDocument) {
+          assert.notEqual(signedDocument.signature, undefined,
+            'signature was not created');
+          assert.equal(signedDocument.signature.creator, testPublicKeyFriendly,
+            'creator key for signature is wrong');
+          testDocumentSigned = signedDocument;
+        }).then(done).catch(done);
       });
-    });
 
-    it('should successfully sign a local document w/promises', function(done) {
-      jsigs.promises.sign(testDocument, {
-        algorithm: 'LinkedDataSignature2015',
-        privateKeyPem: testPrivateKeyPem,
-        creator: testPublicKeyUrl
-      }).then(function(signedDocument) {
-        assert.notEqual(signedDocument.signature, undefined,
-          'signature was not created');
-        assert.equal(signedDocument.signature.creator, testPublicKeyUrl,
-          'creator key for signature is wrong');
-        testDocumentSigned = signedDocument;
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('should successfully verify a local signed document' +
+        ' w/promises API', function(done) {
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }).then(function(verified) {
+          assert.equal(verified, true, 'signature verification failed');
+        }).then(done).catch(done);
       });
-    });
 
-    it('should successfully verify a local signed document w/promises', function(done) {
-      jsigs.promises.verify(testDocumentSigned, {
-        publicKey: testPublicKey,
-        publicKeyOwner: testPublicKeyOwner
-      }).then(function(verified) {
-        assert.equal(verified, true, 'signature verification failed');
-      }).catch(function(err) {
-        assert.ifError(err);
-      }).then(function() {
-        done();
+      it('verify should return false if the document was signed by' +
+        ' a different private key w/promises API', function(done) {
+        testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
+
+        jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }).then(function(verified) {
+          assert.equal(verified, false,
+            'signature verification should have failed but did not');
+        }).then(done).catch(done);
       });
+
     });
 
   });
@@ -590,9 +711,12 @@ var securityContext = {
     "EncryptedMessage": "sec:EncryptedMessage",
     "GraphSignature2012": "sec:GraphSignature2012",
     "LinkedDataSignature2015": "sec:LinkedDataSignature2015",
+    "LinkedDataSignature2016": "sec:LinkedDataSignature2016",
+    "EcdsaKoblitzSignature2016": "sec:EcdsaKoblitzSignature2016",
     "CryptographicKey": "sec:Key",
 
     "authenticationTag": "sec:authenticationTag",
+    "canonicalizationAlgorithm": "sec:canonicalizationAlgorithm",
     "cipherAlgorithm": "sec:cipherAlgorithm",
     "cipherData": "sec:cipherData",
     "cipherKey": "sec:cipherKey",

--- a/tests/test.js
+++ b/tests/test.js
@@ -14,12 +14,14 @@
 var _nodejs = (typeof process !== 'undefined' &&
   process.versions && process.versions.node);
 
+var _jsdir, jsonld, jsigs, assert, program;
+
 if(_nodejs) {
-  var _jsdir = process.env.JSDIR || 'lib';
-  var jsonld = require('../node_modules/jsonld');
-  var jsigs = require('../' + _jsdir + '/jsonld-signatures')();
-  var assert = require('assert');
-  var program = require('commander');
+  _jsdir = process.env.JSDIR || 'lib';
+  jsonld = require('../node_modules/jsonld');
+  jsigs = require('../' + _jsdir + '/jsonld-signatures')();
+  assert = require('assert');
+  program = require('commander');
   program
     .option('--bail', 'Bail when a test fails')
     .parse(process.argv);
@@ -27,19 +29,18 @@ if(_nodejs) {
   var system = require('system');
   require('./bind');
   require('./setImmediate');
-  var _jsdir = system.env.JSDIR || 'lib';
-  var async = require('async');
-  window.async = async;
+  _jsdir = system.env.JSDIR || 'lib';
+  window.async = require('async');
   var forge = require('../node_modules/node-forge');
   window.forge = forge;
   var bitcoreMessage = require('../node_modules/bitcore-message/dist/bitcore-message.js');
   window.bitcoreMessage = bitcoreMessage;
   require('../node_modules/jsonld');
-  var jsonld = jsonldjs;
+  jsonld = jsonldjs;
   require('../' + _jsdir + '/jsonld-signatures');
-  var jsigs = window.jsigs;
+  jsigs = window.jsigs;
   window.Promise = require('es6-promise').Promise;
-  var assert = require('chai').assert;
+  assert = require('chai').assert;
   require('mocha/mocha');
   require('mocha-phantomjs/lib/mocha-phantomjs/core_extensions');
 
@@ -56,7 +57,7 @@ if(_nodejs) {
   };
   jsonld.documentLoader = contextLoader;
 
-  var program = {};
+  program = {};
   for(var i = 0; i < system.args.length; ++i) {
     var arg = system.args[i];
     if(arg.indexOf('--') === 0) {
@@ -271,7 +272,6 @@ describe('JSON-LD Signatures', function() {
         done();
       });
     });
-
   });
 
   describe('signing and verify EcdsaKoblitzSignature2016 w/o security context', function() {
@@ -288,9 +288,9 @@ describe('JSON-LD Signatures', function() {
       image: 'https://manu.sporny.org/images/manu.png'
     };
     var testDocumentSigned = {};
-    var testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw'
-    var testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER'
-    var testPublicKeyFriendly = 'sha256-ecdsa-secp256k1-public-key:' + testPublicKeyWif
+    var testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw';
+    var testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER';
+    var testPublicKeyFriendly = 'bitcoin-key:' + testPublicKeyWif;
 
     var testPublicKeyBtc = {
       '@context': jsigs.SECURITY_CONTEXT_URL,
@@ -350,8 +350,8 @@ describe('JSON-LD Signatures', function() {
       });
     });
 
-    xit('should successfully sign a local document w/promises API')
-    xit('should successfully verify a local signed document w/promises API')
+    xit('should successfully sign a local document w/promises API');
+    xit('should successfully verify a local signed document w/promises API');
 
   });
 


### PR DESCRIPTION
This PR consists of 2 commits:

- 676db48 adds tests for EcdsaKoblitzSignature2016 (BTC) with a security context -- note that [test fail](https://travis-ci.org/CoMakery/jsonld-signatures/builds/181547270) after this commit, because the algorithm name contains a namespace prefix: `sec:EcdsaKoblitzSignature2016`.
- b28ba6b adds a small tweak to strip off the namespace prefix from the algorithm name.  I'm not sure why the prefix ends up there; and we only see it in the EcdsaKoblitzSignature2016 algorithm case.  Tests pass after this commit.  Any better solutions are very welcome.  