### PR TITLE
fix empty message issue with EcdsaKoblitzSignature2016

### DIFF
--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -781,7 +781,7 @@ function _getDataToHash(input, options) {
     if(options.domain !== null && options.domain !== undefined) {
       toHash += '@' + options.domain;
     }
-  } else if(options.algorithm === 'LinkedDataSignature2015') {
+  } else {
     var headers = {
       'http://purl.org/dc/elements/1.1/created': options.date,
       'https://w3id.org/security#domain': options.domain,

--- a/tests/test.js
+++ b/tests/test.js
@@ -276,6 +276,7 @@ describe('JSON-LD Signatures', function() {
       var testPublicKeyBtc;
       var testPublicKeyBtcOwner;
       var invalidPublicKeyWif;
+      var testDocumentSignedAltered;
 
       beforeEach(function() {
         testDocument = {
@@ -295,13 +296,15 @@ describe('JSON-LD Signatures', function() {
           "@type": "EcdsaKoblitzSignature2016",
           "http://purl.org/dc/terms/created": {
             "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-            "@value": "2016-11-30T01:44:34Z"
+            "@value": "2017-03-25T22:01:04Z"
           },
           "http://purl.org/dc/terms/creator": {
             "@id": "ecdsa-koblitz-pubkey:1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER"
           },
-          "https://w3id.org/security#signatureValue": "IEDwNo/X5cQx0ZQwXx1Qt5kO+gQQ0IPgURC/SpmbRT5lWUC65QByTDkqu6OWKRcZ0EbRZlV/NVUNr+XExxTmECI="
+          "https://w3id.org/security#signatureValue": "IOoF0rMmpcdxNZFoirTpRMCyLr8kGHLqXFl7v+m3naetCx+OLNhVY/6SCUwDGZfFs4yPXeAl6Tj1WgtLIHOVZmw="
         };
+        testDocumentSignedAltered = clone(testDocumentSigned);
+        testDocumentSignedAltered.name = 'Manu Spornoneous';
 
         testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw';
         testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER';
@@ -357,6 +360,17 @@ describe('JSON-LD Signatures', function() {
         testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
 
         jsigs.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }, function(err, verified) {
+          assert.ifError(err);
+          assert.equal(verified, false, 'signature verification should have failed');
+          done();
+        });
+      });
+
+      it('verify should return false if the document was altered after signing', function(done) {
+        jsigs.verify(testDocumentSignedAltered, {
           publicKey: testPublicKeyBtc,
           publicKeyOwner: testPublicKeyBtcOwner
         }, function(err, verified) {
@@ -553,6 +567,7 @@ describe('JSON-LD Signatures', function() {
       var testPublicKeyBtc;
       var testPublicKeyBtcOwner;
       var invalidPublicKeyWif;
+      var testDocumentSignedAltered;
 
       beforeEach(function() {
         testDocument = {
@@ -572,13 +587,15 @@ describe('JSON-LD Signatures', function() {
           "@type": "EcdsaKoblitzSignature2016",
           "http://purl.org/dc/terms/created": {
             "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
-            "@value": "2016-11-30T01:44:34Z"
+            "@value": "2017-03-25T22:01:04Z"
           },
           "http://purl.org/dc/terms/creator": {
             "@id": "ecdsa-koblitz-pubkey:1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER"
           },
-          "https://w3id.org/security#signatureValue": "IEDwNo/X5cQx0ZQwXx1Qt5kO+gQQ0IPgURC/SpmbRT5lWUC65QByTDkqu6OWKRcZ0EbRZlV/NVUNr+XExxTmECI="
+          "https://w3id.org/security#signatureValue": "IOoF0rMmpcdxNZFoirTpRMCyLr8kGHLqXFl7v+m3naetCx+OLNhVY/6SCUwDGZfFs4yPXeAl6Tj1WgtLIHOVZmw="
         };
+        testDocumentSignedAltered = clone(testDocumentSigned);
+        testDocumentSignedAltered.name = 'Manu Spornoneous';
 
         testPrivateKeyWif = 'L4mEi7eEdTNNFQEWaa7JhUKAbtHdVvByGAqvpJKC53mfiqunjBjw';
         testPublicKeyWif = '1LGpGhGK8whX23ZNdxrgtjKrek9rP4xWER';
@@ -671,6 +688,17 @@ describe('JSON-LD Signatures', function() {
         testPublicKeyBtc.publicKeyWif = invalidPublicKeyWif;
 
         jsigs.promises.verify(testDocumentSigned, {
+          publicKey: testPublicKeyBtc,
+          publicKeyOwner: testPublicKeyBtcOwner
+        }).then(function(verified) {
+          assert.equal(verified, false,
+            'signature verification should have failed but did not');
+        }).then(done).catch(done);
+      });
+
+      it('verify should return false if the document was altered after' +
+        ' signing w/promises API', function(done) {
+        jsigs.promises.verify(testDocumentSignedAltered, {
           publicKey: testPublicKeyBtc,
           publicKeyOwner: testPublicKeyBtcOwner
         }).then(function(verified) {


### PR DESCRIPTION
I noticed an issue with the EcdsaKoblitzSignature2016 codepaths. `_getDataToHash` returns an empty string if options.algorithm is EcdsaKoblitzSignature2016. That means it's currently signing (and verifying) the empty message.

This is a security issue for any callers using the EcdsaKoblitzSignature2016 codepath, as _any_ message given to it gets dropped. I.e. when signing, the input message is dropped and the empty message is signed. If the same signed message is tampered with, then it will also continue to verify. Again, this is because the message is being dropped during `_getDataToHash`, and the empty message will verify.

Note that I also needed to update the signatureValues in unit tests.

This PR was originally posted as https://github.com/w3c-vc/playground/pull/1, and moved here per @msporny's feedback. 

/cc: @harlantwood @dlongley @davidlehn 