### PR TITLE
Update for newer jsonld.

### DIFF
--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -111,8 +111,7 @@ api.use = function(name, injectable) {
       'bitcoreMessage': 'bitcore-message'
     };
     var requireName = requireAliases[name] || name;
-    var globalName = (name === 'jsonld' ? 'jsonldjs' : name);
-    libs[name] = global[globalName] || (_nodejs && require(requireName));
+    libs[name] = global[name] || (_nodejs && require(requireName));
     if(name === 'jsonld') {
       if(_nodejs) {
         // locally configure jsonld

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "bitcore-message": "github:CoMakery/bitcore-message#dist",
     "commander": "~2.9.0",
     "es6-promise": "^4.0.5",
-    "jsonld": "0.4.3",
+    "jsonld": "^0.5.0",
     "node-forge": "~0.7.1"
   },
   "devDependencies": {

--- a/tests/test.js
+++ b/tests/test.js
@@ -6,7 +6,6 @@
  *
  * Copyright (c) 2014-2017 Digital Bazaar, Inc. All rights reserved.
  */
-/* globals jsonldjs */
 (function() {
 
 'use strict';
@@ -82,10 +81,11 @@ if(_nodejs) {
   var bitcoreMessage = require(
     '../node_modules/bitcore-message/dist/bitcore-message.js');
   window.bitcoreMessage = bitcoreMessage;
-  require('../node_modules/jsonld');
-  jsonld = jsonldjs;
+  jsonld = require('../node_modules/jsonld/dist/jsonld.js');
   require('../' + _jsdir + '/jsonld-signatures');
   jsigs = window.jsigs;
+  jsigs.use('jsonld', jsonld);
+  jsigs.promises({api: jsigs.promises});
   assert = require('chai').assert;
   require('mocha/mocha');
   require('mocha-phantomjs/lib/mocha-phantomjs/core_extensions');


### PR DESCRIPTION
Fixes issues with using jsonld.js 0.5.x.  The jsonld dep may need to be fixed but if you use a 0.5.x github dep it doesn't install the devdeps in order to build the node6 or browser bundle.  But those are needed for tests.  Unsure what to do about that but this will fix it if linking to a local and built jsonld install.