### PR TITLE
Add `authenticationCredential` to frame.

### DIFF
--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -482,7 +482,9 @@ api.checkKey = function(key, options, callback) {
     // frame owner
     var frame = {
       '@context': api.SECURITY_CONTEXT_URL,
-      publicKey: {'@embed': '@never'}
+      '@requireAll': false,
+      publicKey: {'@embed': '@never'},
+      authenticationCredential: {'@embed': '@never'}
     };
     return jsonld.promises.frame(owner, frame).then(function(framed) {
       return framed['@graph'];
@@ -493,7 +495,8 @@ api.checkKey = function(key, options, callback) {
     // find specific owner of key
     var owner;
     for(var i = 0; i < owners.length; ++i) {
-      if(jsonld.hasValue(owners[i], 'publicKey', _framedKey.id)) {
+      if(jsonld.hasValue(owners[i], 'publicKey', _framedKey.id) ||
+        jsonld.hasValue(owners[i], 'authenticationCredential', _framedKey.id)) {
         owner = owners[i];
         break;
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsonld-signatures",
-  "version": "1.2.2-0",
+  "version": "1.2.2-2",
   "description": "An implementation of the Linked Data Signatures specification for JSON-LD in node.js.",
   "homepage": "http://github.com/digitalbazaar/jsonld-signatures",
   "author": {


### PR DESCRIPTION
@dlongley the test suite does not appear to use local copies of contexts. So, public contexts will need to be updated before tests can be created for this patch.

EDIT: with the `@requireAll: false`, both terms appear in the framed output, but the missing one will be set to `null` which works properly since we are testing that the property is set to the `_framedKey.id`