### PR TITLE
Optimize `LinkedDataSignature` `createVerifyData`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - "6"
   - "8"
+  - "10"
   - "node"
 sudo: false
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # jsonld-signatures ChangeLog
 
+### Changed
+- Optimize `LinkedDataSignature` `createVerifyData` to remove
+  one round of compaction and one round of expansion. This
+  eliminates a total of four rounds (2x compaction, 2x expansion)
+  for sign+verify processes as `createVerifyData` is used
+  in both `sign` and `verify`.
+
 ## 2.3.0 - 2018-03-20
 
 ### Added

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -6,5 +6,6 @@
 module.exports = {
   SECURITY_CONTEXT_URL: 'https://w3id.org/security/v2',
   SECURITY_CONTEXT_V1_URL: 'https://w3id.org/security/v1',
-  SECURITY_CONTEXT_V2_URL: 'https://w3id.org/security/v2'
+  SECURITY_CONTEXT_V2_URL: 'https://w3id.org/security/v2',
+  SECURITY_PROOF_URL: 'https://w3id.org/security#proof'
 };

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -25,7 +25,8 @@ module.exports = class LinkedDataSignature {
     const opts = {
       algorithm: 'URDNA2015',
       format: 'application/n-quads',
-      expansionMap: options.expansionMap
+      expansionMap: options.expansionMap,
+      skipExpansion: options.skipExpansion === true
     };
     if(options.documentLoader) {
       opts.documentLoader = options.documentLoader;
@@ -37,27 +38,26 @@ module.exports = class LinkedDataSignature {
     // TODO: frame before getting signature, not just compact? considerations:
     // should the assumption be (for this library) that the signature is on
     // the top-level object and thus framing is unnecessary?
-
     const jsonld = this.injector.use('jsonld');
     const opts = {expansionMap: options.expansionMap};
     if(options.documentLoader) {
       opts.documentLoader = options.documentLoader;
     }
-    const compacted = await jsonld.compact(
-      input, constants.SECURITY_CONTEXT_URL, opts);
+    const [expanded = {}] = await jsonld.expand(input, opts);
 
     // TODO: will need to preserve `proof` when chained signature
     // option is used and implemented in the future
 
     // delete the existing proofs(s) prior to canonicalization
-    delete compacted.proof;
+    delete expanded[constants.SECURITY_PROOF_URL];
 
     // ensure signature values are removed from proof node
     const proof = await this.sanitizeProofNode(options.proof, options);
 
     // concatenate hash of c14n proof options and hash of c14n document
     const c14nProofOptions = await this.canonize(proof, options);
-    const c14nDocument = await this.canonize(compacted, options);
+    const canonizeOptions = Object.assign({}, options, {skipExpansion: true});
+    const c14nDocument = await this.canonize(expanded, canonizeOptions);
     return {
       data: this._sha256(c14nProofOptions).getBytes() +
         this._sha256(c14nDocument).getBytes(),

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "bitcore-message": "github:CoMakery/bitcore-message#dist",
     "bs58": "^4.0.1",
     "chloride": "^2.2.8",
-    "jsonld": "^1.0.1",
+    "jsonld": "^1.1.0",
     "node-forge": "^0.7.4",
     "semver": "^5.5.0"
   },


### PR DESCRIPTION
- Remove one round of compaction and one round of expansion.
- Removes 4 rounds for sign+verify processes.