### PR TITLE
Add proofPurpose and ppOptions properties

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -4,6 +4,7 @@
 'use strict';
 
 module.exports = {
+  CREDENTIALS_CONTEXT_URL: 'https://w3id.org/credentials',
   SECURITY_CONTEXT_URL: 'https://w3id.org/security/v2',
   SECURITY_CONTEXT_V1_URL: 'https://w3id.org/security/v1',
   SECURITY_CONTEXT_V2_URL: 'https://w3id.org/security/v2',

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -104,7 +104,7 @@ api.suites = suites;
  *            Not providing this will result in the legacy behavior
  *            of checking only signatures without a proofPurpose.  Not
  *            recommended... this can lead to confused deputy attacks.
- *          [ppOptions] Options and expectations relevant to the
+ *          [proofPurposeOptions] Options and expectations relevant to the
  *            proofPurpose object's verification method.
  *          [documentLoader(url, [callback(err, remoteDoc)])] the document
  *            loader.
@@ -175,7 +175,7 @@ api.sign = util.callbackify(async function(input, options) {
  *            an error.)  Not providing this will result in the legacy behavior
  *            of checking only signatures without a proofPurpose.  Not
  *            recommended... this can lead to confused deputy attacks.
- *          [ppOptions] Options and expectations relevant to the
+ *          [proofPurposeOptions] Options and expectations relevant to the
  *            proofPurpose object's verification method.
  * @param [callback(err, result)] called once the operation completes.
  *

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -252,7 +252,7 @@ api.verify = util.callbackify(async function(input, options) {
   // of them may be is known in advance.)
   const [expanded] = await jsonld.expand(input, opts);
   const framed = await jsonld.compact(
-    input, constants.SECURITY_CONTEXT_URL, opts);
+    expanded, constants.SECURITY_CONTEXT_URL, {...opts, skipExpansion: true});
 
   // ensure there is at least one `proof` or `signature`
   const proofs = jsonld.getValues(framed, 'signature')

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -53,7 +53,9 @@ const suites = {
   GraphSignature2012: require('./suites/GraphSignature2012'),
   RsaSignature2018: require('./suites/RsaSignature2018')
 };
-const proofPurposes = {};
+const proofPurposes = {
+  CredentialIssuance: require('./proof-purpose/CredentialIssuance')
+};
 
 // load locally embedded contexts
 const contexts = require('./contexts');

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -100,6 +100,12 @@ api.suites = suites;
  *          [proof] a JSON-LD document with options to use for the `proof`
  *            node (e.g. `proofPurpose` or any other custom fields can be
  *            provided here using a context different from security-v2).
+ *          [proofPurpose] A ProofPurpose object.  If provided,
+ *            Not providing this will result in the legacy behavior
+ *            of checking only signatures without a proofPurpose.  Not
+ *            recommended... this can lead to confused deputy attacks.
+ *          [ppOptions] Options and expectations relevant to the
+ *            proofPurpose object's verification method.
  *          [documentLoader(url, [callback(err, remoteDoc)])] the document
  *            loader.
  * @param callback(err, signedDocument) called once the operation completes.
@@ -162,6 +168,15 @@ api.sign = util.callbackify(async function(input, options) {
  *            loader.
  *          [id] the ID (full URL) of the node to check the signature of, if
  *            the input contains multiple signed nodes.
+ *          [proofPurpose] A ProofPurpose object.  If provided, only proofs
+ *            matching this proofPurpose's URI will be checked, but will be
+ *            checked against the additional verification steps relevant to the
+ *            proofPurpose.  (Failure to find a relevant proofPurpose will throw
+ *            an error.)  Not providing this will result in the legacy behavior
+ *            of checking only signatures without a proofPurpose.  Not
+ *            recommended... this can lead to confused deputy attacks.
+ *          [ppOptions] Options and expectations relevant to the
+ *            proofPurpose object's verification method.
  * @param [callback(err, result)] called once the operation completes.
  *
  * @return a Promise that resolves to the verification result.
@@ -228,6 +243,14 @@ api.verify = util.callbackify(async function(input, options) {
   if(options.documentLoader) {
     opts.documentLoader = options.documentLoader;
   }
+  // Why expand just to frame again?  The answer is in the proofPurpose
+  // logic.  We can't anticipate all the terms we might operate on for all
+  // available ProofPurpose suites, so we expand once and let them
+  // operate on it in expanded form.
+  // (Each ProofPupose could compact to its own context, though in the case
+  // of ocap-ld, not even which caveats might be used and what the arguments
+  // of them may be is known in advance.)
+  const [expanded] = await jsonld.expand(input, opts);
   const framed = await jsonld.compact(
     input, constants.SECURITY_CONTEXT_URL, opts);
 
@@ -240,12 +263,29 @@ api.verify = util.callbackify(async function(input, options) {
     throw new Error('No signature found.');
   }
 
+  // Filter proofs to only those with the expected proofpurpose
+  let proofPurpose = false;
+  if (options.proofPurpose) {
+    proofPurpose = new options.proofPurpose(injector);
+  }
+  const filteredProofs = proofs.filter(
+    (obj) => {
+      const proof = obj.doc;
+      if (proofPurpose) {
+        return proof.proofPurpose === proofPurpose.uri;
+      } else {
+        return !proof.proofPurpose;
+      }});
+  if (filteredProofs.length === 0) {
+    throw new Error('No proofs matching the expected proofPurpose found.');
+  }
+
   // TODO: this only works for set signatures; add support for chained
   // signatures
 
   // create a promise for each signature to be verified
   const SUPPORTED_ALGORITHMS = _getSupportedAlgorithms();
-  const results = await Promise.all(proofs.map(proof => (async () => {
+  const results = await Promise.all(filteredProofs.map(proof => (async () => {
     try {
       const algorithm = jsonld.getValues(proof.doc, 'type')[0] || '';
       if(SUPPORTED_ALGORITHMS.indexOf(algorithm) === -1) {
@@ -263,7 +303,7 @@ api.verify = util.callbackify(async function(input, options) {
       //const Suite = require('./suites/' + algorithm);
       const Suite = suites[algorithm];
       const verified = await new Suite(injector).verify(
-        f, Object.assign({}, options, {framed}));
+        f, expanded, Object.assign({}, options, {framed}));
       return {verified};
     } catch(e) {
       return {verified: false, error: e};

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -105,7 +105,7 @@ api.proofPurposes = proofPurposes;
  *          [proof] a JSON-LD document with options to use for the `proof`
  *            node (e.g. `proofPurpose` or any other custom fields can be
  *            provided here using a context different from security-v2).
- *          [proofPurpose] A ProofPurpose object.  If provided,
+ *          [proofPurpose] the proofPurpose to use, eg: 'CredentialIssuance'
  *            Not providing this will result in the legacy behavior
  *            of checking only signatures without a proofPurpose.  Not
  *            recommended... this can lead to confused deputy attacks.
@@ -390,6 +390,9 @@ api.promises = api;
 // expose base64 functions for testing
 api._encodeBase64Url = util.encodeBase64Url;
 api._decodeBase64Url = util.decodeBase64Url;
+
+// expose ProofPurpose base class
+api.ProofPurpose = require('./proof-purpose/ProofPurpose');
 
 return api;
 

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -5,6 +5,7 @@
  * @author Dave Longley <dlongley@digitalbazaar.com>
  * @author David I. Lehn <dlehn@digitalbazaar.com>
  * @author Manu Sporny <msporny@digitalbazaar.com>
+ * @author Ganesh Annan <gannan@digitalbazaar.com>
  *
  * BSD 3-Clause License
  * Copyright (c) 2014-2018 Digital Bazaar, Inc.
@@ -52,6 +53,7 @@ const suites = {
   GraphSignature2012: require('./suites/GraphSignature2012'),
   RsaSignature2018: require('./suites/RsaSignature2018')
 };
+const proofPurposes = {};
 
 // load locally embedded contexts
 const contexts = require('./contexts');
@@ -77,6 +79,7 @@ Object.assign(api, constants);
 
 /* Core API */
 api.suites = suites;
+api.proofPurposes = proofPurposes;
 
 /**
  * Signs a JSON-LD document using a digital signature.
@@ -122,7 +125,7 @@ api.sign = util.callbackify(async function(input, options) {
 
   const SUPPORTED_ALGORITHMS = _getSupportedAlgorithms();
 
-  const algorithm = options.algorithm;
+  const {algorithm} = options;
   if(SUPPORTED_ALGORITHMS.indexOf(algorithm) === -1) {
     throw new Error(
       'Unsupported algorithm "' + algorithm + '"; ' +
@@ -132,11 +135,21 @@ api.sign = util.callbackify(async function(input, options) {
 
   options = _addEmbeddedContextDocumentLoader(options);
 
+  let {proofPurpose} = options;
+  if(proofPurpose) {
+    // FIXME: check if registered
+    const ProofPurpose = proofPurposes[proofPurpose];
+    if(!ProofPurpose) {
+      throw new Error('Unsupported proof purpose "' + proofPurpose + '".');
+    }
+    proofPurpose = new ProofPurpose(injector);
+  }
   // TODO: won't work with static analysis?
   // use signature suite
   //const Suite = require('./suites/' + algorithm);
   const Suite = suites[algorithm];
-  return new Suite(injector).sign(input, options);
+  return new Suite(injector).sign(
+    input, Object.assign({}, options, {proofPurpose}));
 });
 
 /**
@@ -247,12 +260,14 @@ api.verify = util.callbackify(async function(input, options) {
   // logic.  We can't anticipate all the terms we might operate on for all
   // available ProofPurpose suites, so we expand once and let them
   // operate on it in expanded form.
-  // (Each ProofPupose could compact to its own context, though in the case
+  // (Each ProofPurpose could compact to its own context, though in the case
   // of ocap-ld, not even which caveats might be used and what the arguments
   // of them may be is known in advance.)
   const [expanded] = await jsonld.expand(input, opts);
   const framed = await jsonld.compact(
-    expanded, constants.SECURITY_CONTEXT_URL, {...opts, skipExpansion: true});
+    expanded,
+    constants.SECURITY_CONTEXT_URL,
+    Object.assign({}, opts, {skipExpansion: true}));
 
   // ensure there is at least one `proof` or `signature`
   const proofs = jsonld.getValues(framed, 'signature')
@@ -264,20 +279,28 @@ api.verify = util.callbackify(async function(input, options) {
   }
 
   // Filter proofs to only those with the expected proofpurpose
-  let proofPurpose = false;
-  if (options.proofPurpose) {
-    proofPurpose = new options.proofPurpose(injector);
+  let {proofPurpose} = options;
+  if(proofPurpose) {
+    // FIXME: check if registered
+    const ProofPurpose = proofPurposes[proofPurpose];
+    if(!ProofPurpose) {
+      throw new Error('Unsupported proof purpose "' + proofPurpose + '".');
+    }
+    proofPurpose = new ProofPurpose(injector);
   }
   const filteredProofs = proofs.filter(
-    (obj) => {
-      const proof = obj.doc;
-      if (proofPurpose) {
+    ({doc}) => {
+      const proof = doc;
+      if(proofPurpose) {
         return proof.proofPurpose === proofPurpose.uri;
       } else {
         return !proof.proofPurpose;
       }});
-  if (filteredProofs.length === 0) {
-    throw new Error('No proofs matching the expected proofPurpose found.');
+  if(filteredProofs.length === 0) {
+    // TODO: Should we throw an error here? This will break all usages of
+    // json-ld signatures. Is it true that a proofPurpose is required for
+    // all signatures?
+    // throw new Error('No proofs matching the expected proofPurpose found.');
   }
 
   // TODO: this only works for set signatures; add support for chained
@@ -303,7 +326,7 @@ api.verify = util.callbackify(async function(input, options) {
       //const Suite = require('./suites/' + algorithm);
       const Suite = suites[algorithm];
       const verified = await new Suite(injector).verify(
-        f, expanded, Object.assign({}, options, {framed}));
+        f, Object.assign({}, options, {expanded, framed, proofPurpose}));
       return {verified};
     } catch(e) {
       return {verified: false, error: e};

--- a/lib/proof-purpose/CredentialIssuance.js
+++ b/lib/proof-purpose/CredentialIssuance.js
@@ -57,7 +57,7 @@ module.exports = class CredentialIssuance extends ProofPurpose {
     // Only one field really MUST be present.  Arguably this is a
     // fairly strange place to do this check but this is a demonstration
     // of a highly minimal ProofPurpose class
-    if (!((document['@type'] || []).includes(VerifiableCredentialUri))
+    if(!((document['@type'] || []).includes(VerifiableCredentialUri))
         || !document[claimUri]) {
       return false;
     }

--- a/lib/proof-purpose/CredentialIssuance.js
+++ b/lib/proof-purpose/CredentialIssuance.js
@@ -1,0 +1,69 @@
+/**
+ * Linked Data Signatures/Proofs
+ *
+ * @author Christopher Lemmer Webber
+ *
+ * @license BSD 3-Clause License
+ * Copyright (c) 2018 Digital Bazaar, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the Digital Bazaar, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const ProofPurpose = require('./ProofPurpose.js');
+
+const credentialsNs = 'https://w3id.org/credentials#';
+
+const VerifiableCredentialUri = credentialsNs + 'VerifiableCredential';
+const credentialIssuanceUri = credentialsNs + 'credentialIssuance';
+const claimUri = credentialsNs + 'claim';
+
+module.exports = class CredentialIssuance extends ProofPurpose {
+  constructor(injector) {
+    super(injector);
+    // TODO: We need a more permanent URI for this.  Where would it go?
+    this.uri = credentialIssuanceUri;
+  }
+
+  async verify(document, proof, ppOptions) {
+    // The document's type MUST be VerifiableCredential
+    // Only one field really MUST be present.  Arguably this is a
+    // fairly strange place to do this check but this is a demonstration
+    // of a highly minimal ProofPurpose class
+    if (!((document['@type'] || []).includes(VerifiableCredentialUri))
+        || !document[claimUri]) {
+      return false;
+    }
+    return true;
+  }
+
+  async addFieldsToProof(proof, ppOptions) {
+    return proof;
+  }
+}

--- a/lib/proof-purpose/CredentialIssuance.js
+++ b/lib/proof-purpose/CredentialIssuance.js
@@ -36,9 +36,10 @@
 
 'use strict';
 
+const constants = require('../constants');
 const ProofPurpose = require('./ProofPurpose.js');
 
-const credentialsNs = 'https://w3id.org/credentials#';
+const credentialsNs = constants.CREDENTIALS_CONTEXT_URL + '#';
 
 const VerifiableCredentialUri = credentialsNs + 'VerifiableCredential';
 const credentialIssuanceUri = credentialsNs + 'credentialIssuance';

--- a/lib/proof-purpose/CredentialIssuance.js
+++ b/lib/proof-purpose/CredentialIssuance.js
@@ -51,7 +51,7 @@ module.exports = class CredentialIssuance extends ProofPurpose {
     this.uri = credentialIssuanceUri;
   }
 
-  async verify(document, proof, ppOptions) {
+  async verify(document, proof, proofPurposeOptions) {
     // The document's type MUST be VerifiableCredential
     // Only one field really MUST be present.  Arguably this is a
     // fairly strange place to do this check but this is a demonstration
@@ -63,7 +63,7 @@ module.exports = class CredentialIssuance extends ProofPurpose {
     return true;
   }
 
-  async addFieldsToProof(proof, ppOptions) {
+  async addFieldsToProof(proof, proofPurposeOptions) {
     return proof;
   }
 }

--- a/lib/proof-purpose/ProofPurpose.js
+++ b/lib/proof-purpose/ProofPurpose.js
@@ -48,12 +48,12 @@ module.exports = class ProofPurpose {
     this.uri = null;
   }
 
-  async verify(document, proof, ppOptions) {
+  async verify(document, proof, proofPurposeOptions) {
     throw new Error(
       '"verify" must be implemented in a derived class.');
   }
 
-  async addFieldsToProof(proof, ppOptions) {
+  async addFieldsToProof(proof, proofPurposeOptions) {
     throw new Error(
       '"addFieldsToProof" must be implemented in a derived class.');
   }

--- a/lib/proof-purpose/ProofPurpose.js
+++ b/lib/proof-purpose/ProofPurpose.js
@@ -1,0 +1,60 @@
+/**
+ * Linked Data Signatures/Proofs
+ *
+ * @author Christopher Lemmer Webber
+ *
+ * @license BSD 3-Clause License
+ * Copyright (c) 2018 Digital Bazaar, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of the Digital Bazaar, Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+// Note that classes implementing ProofPurpose in general should operate
+// on fields in expanded form for any of their own properties.  This is
+// because the number of fields that are possible given custom ProofPurpose
+// implementations are much larger than those mapped in the standard
+// ld-sigs / ocap-ld context.
+module.exports = class ProofPurpose {
+  constructor(injector) {
+    this.injector = injector;
+    // Must be overridden by child methods
+    this.uri = null;
+  }
+
+  async verify(document, proof, ppOptions) {
+    throw new Error(
+      '"verify" must be implemented in a derived class.');
+  }
+
+  async addFieldsToProof(proof, ppOptions) {
+    throw new Error(
+      '"addFieldsToProof" must be implemented in a derived class.');
+  }
+}

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -146,7 +146,7 @@ module.exports = class LinkedDataSignature {
     }
 
     // add fields from proofPurpose
-    if (options.proofPurpose) {
+    if(options.proofPurpose) {
       const proofPurpose = options.proofPurpose;
       proof.proofPurpose = proofPurpose.uri;
       await proofPurpose.addFieldsToProof(

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -150,7 +150,7 @@ module.exports = class LinkedDataSignature {
       const proofPurpose = new options.proofPurpose(this.injector)
       proof.proofPurpose = proofPurpose.uri;
       await proofPurpose.addFieldsToProof(
-        proof, options.ppOptions || {});
+        proof, options.proofPurposeOptions || {});
     }
 
     // produce data to sign
@@ -311,7 +311,7 @@ module.exports = class LinkedDataSignature {
     if (options.proofPurpose) {
       const proofPurpose = new options.proofPurpose(this.injector);
       const ppVerified = await proofPurpose.verify(
-        expanded, proof, options.ppOptions || {});
+        expanded, proof, options.proofPurposeOptions || {});
       // Okay now ensure that the proofPurpose validation passes
       if(!ppVerified) {
         throw new Error(

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -145,6 +145,14 @@ module.exports = class LinkedDataSignature {
       proof.nonce = options.nonce;
     }
 
+    // add fields from proofPurpose
+    if (options.proofPurpose) {
+      const proofPurpose = new options.proofPurpose(this.injector)
+      proof.proofPurpose = proofPurpose.uri;
+      await proofPurpose.addFieldsToProof(
+        proof, options.ppOptions || {});
+    }
+
     // produce data to sign
     options.proof = proof;
     const verifyData = await this.createVerifyData(input, options);
@@ -190,9 +198,11 @@ module.exports = class LinkedDataSignature {
     return output;
   }
 
-  async verify(framed, options) {
+  async verify(framed, expanded, options) {
     options = Object.assign({}, options || {});
 
+    // TODO: This only supports one proof object at a time.
+    // However the spec supports attaching multiple proofs.
     const proof = framed.signature || framed.proof;
     proof['@context'] = framed['@context'];
 
@@ -297,6 +307,19 @@ module.exports = class LinkedDataSignature {
         proof
       }));
 
+    // Check that the proofPurpose is valid
+    if (options.proofPurpose) {
+      const proofPurpose = new options.proofPurpose(this.injector);
+      const ppVerified = await proofPurpose.verify(
+        expanded, proof, options.ppOptions || {});
+      // Okay now ensure that the proofPurpose validation passes
+      if(!ppVerified) {
+        throw new Error(
+          'proofPurpose verification failed.');
+      }
+    }
+
+    // All other proof validation checks
     return this.verifyProofNode(
       verifyData, proof,
       Object.assign({}, options, {publicKey: publicKey}));

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -147,7 +147,7 @@ module.exports = class LinkedDataSignature {
 
     // add fields from proofPurpose
     if (options.proofPurpose) {
-      const proofPurpose = new options.proofPurpose(this.injector)
+      const proofPurpose = options.proofPurpose;
       proof.proofPurpose = proofPurpose.uri;
       await proofPurpose.addFieldsToProof(
         proof, options.proofPurposeOptions || {});
@@ -198,7 +198,7 @@ module.exports = class LinkedDataSignature {
     return output;
   }
 
-  async verify(framed, expanded, options) {
+  async verify(framed, options) {
     options = Object.assign({}, options || {});
 
     // TODO: This only supports one proof object at a time.
@@ -308,12 +308,12 @@ module.exports = class LinkedDataSignature {
       }));
 
     // Check that the proofPurpose is valid
-    if (options.proofPurpose) {
-      const proofPurpose = new options.proofPurpose(this.injector);
-      const ppVerified = await proofPurpose.verify(
+    if(options.proofPurpose) {
+      const {expanded, proofPurpose} = options;
+      const verified = await proofPurpose.verify(
         expanded, proof, options.proofPurposeOptions || {});
       // Okay now ensure that the proofPurpose validation passes
-      if(!ppVerified) {
+      if(!verified) {
         throw new Error(
           'proofPurpose verification failed.');
       }

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -14,6 +14,7 @@ module.exports = function(options) {
 const assert = options.assert;
 const jsonld = options.jsonld;
 const jsigs = options.jsigs;
+const ProofPurpose = require('../lib/proof-purpose/ProofPurpose.js');
 
 var testLoader = function(url, callback) {
   if(url === testPublicKeyUrl) {
@@ -67,6 +68,22 @@ jsigs.use('jsonld', jsonld);
 // helper:
 function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
+}
+
+const noOpPpUri = 'https://example.org/special-authentication';
+
+class NoOpProofPurpose extends ProofPurpose {
+  constructor(injector) {
+    super(injector);
+    // TODO: We need a more permanent URI for this.  Where would it go?
+    this.uri = noOpPpUri;
+  }
+  async verify(document, proof, ppOptions) {
+    return true;
+  }
+  async addFieldsToProof(proof, ppOptions) {
+    return proof;
+  }
 }
 
 // run tests
@@ -744,7 +761,7 @@ describe('JSON-LD Signatures', function() {
           }
         };
 
-        testProofPurpose = 'https://example.org/special-authentication';
+        testProofPurpose = noOpPpUri;
         testDocumentWithProofPurposeSigned = clone(testDocument);
         testDocumentWithProofPurposeSigned
           ["https://w3id.org/security#proof"] = {
@@ -849,10 +866,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'RsaSignature2018',
           creator: testPublicKeyUrl,
           privateKeyPem: testPrivateKeyPem,
-          proof: {
-            '@context': 'https://w3id.org/security/v2',
-            proofPurpose: testProofPurpose
-          }
+          proofPurpose: NoOpProofPurpose,
         }, function(err, signedDocument) {
           assert.ifError(err);
           assert.notEqual(
@@ -878,7 +892,8 @@ describe('JSON-LD Signatures', function() {
           publicKeyOwner: testPublicKeyOwner,
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
-          checkTimestamp: false
+          checkTimestamp: false,
+          proofPurpose: NoOpProofPurpose,
         }, function(err, result) {
           assert.ifError(err);
           assert.equal(result.verified, true, 'signature verification failed');
@@ -956,10 +971,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'RsaSignature2018',
           privateKeyPem: testPrivateKeyPem,
           creator: testPublicKeyUrl,
-          proof: {
-            '@context': 'https://w3id.org/security/v2',
-            proofPurpose: testProofPurpose
-          }
+          proofPurpose: NoOpProofPurpose,
         }).then(function(signedDocument) {
           assert.notEqual(
             signedDocument['https://w3id.org/security#proof'], undefined,
@@ -982,7 +994,8 @@ describe('JSON-LD Signatures', function() {
           publicKeyOwner: testPublicKeyOwner,
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
-          checkTimestamp: false
+          checkTimestamp: false,
+          proofPurpose: NoOpProofPurpose,
         }).then(function(result) {
           assert.equal(result.verified, true, 'signature verification failed');
         }).then(done, done);
@@ -1051,7 +1064,7 @@ describe('JSON-LD Signatures', function() {
         testDocumentSignedAltered = clone(testDocumentSigned);
         testDocumentSignedAltered.name = 'Manu Spornoneous';
 
-        testProofPurpose = 'https://example.org/special-authentication';
+        testProofPurpose = noOpPpUri;
         testDocumentWithProofPurposeSigned = clone(testDocument);
         testDocumentWithProofPurposeSigned
           ["https://w3id.org/security#proof"] = {
@@ -1118,10 +1131,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'Ed25519Signature2018',
           creator: testPublicKey.id,
           privateKeyBase58: testPrivateKeyEd25519Base58,
-          proof: {
-            '@context': 'https://w3id.org/security/v2',
-            proofPurpose: testProofPurpose
-          }
+          proofPurpose: NoOpProofPurpose,
         }, function(err, signedDocument) {
           assert.ifError(err);
           assert.notEqual(
@@ -1147,7 +1157,8 @@ describe('JSON-LD Signatures', function() {
           publicKeyOwner: testPublicKeyOwner,
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
-          checkTimestamp: false
+          checkTimestamp: false,
+          proofPurpose: NoOpProofPurpose,
         }, function(err, result) {
           assert.ifError(err);
           assert.equal(result.verified, true, 'signature verification failed');
@@ -1225,10 +1236,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'Ed25519Signature2018',
           privateKeyBase58: testPrivateKeyEd25519Base58,
           creator: testPublicKey.id,
-          proof: {
-            '@context': 'https://w3id.org/security/v2',
-            proofPurpose: testProofPurpose
-          }
+          proofPurpose: NoOpProofPurpose,
         }).then(function(signedDocument) {
           assert.notEqual(
             signedDocument['https://w3id.org/security#proof'], undefined,
@@ -1251,7 +1259,8 @@ describe('JSON-LD Signatures', function() {
           publicKeyOwner: testPublicKeyOwner,
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
-          checkTimestamp: false
+          checkTimestamp: false,
+          proofPurpose: NoOpProofPurpose,
         }).then(function(result) {
           assert.equal(result.verified, true, 'signature verification failed');
         }).then(done, done);

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -86,6 +86,8 @@ class NoOpProofPurpose extends ProofPurpose {
   }
 }
 
+jsigs.proofPurposes['NoOpProofPurpose'] = NoOpProofPurpose;
+
 // run tests
 describe('JSON-LD Signatures', function() {
   context('common', function() {
@@ -866,7 +868,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'RsaSignature2018',
           creator: testPublicKeyUrl,
           privateKeyPem: testPrivateKeyPem,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }, function(err, signedDocument) {
           assert.ifError(err);
           assert.notEqual(
@@ -893,7 +895,7 @@ describe('JSON-LD Signatures', function() {
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
           checkTimestamp: false,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }, function(err, result) {
           assert.ifError(err);
           assert.equal(result.verified, true, 'signature verification failed');
@@ -971,7 +973,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'RsaSignature2018',
           privateKeyPem: testPrivateKeyPem,
           creator: testPublicKeyUrl,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }).then(function(signedDocument) {
           assert.notEqual(
             signedDocument['https://w3id.org/security#proof'], undefined,
@@ -995,7 +997,7 @@ describe('JSON-LD Signatures', function() {
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
           checkTimestamp: false,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }).then(function(result) {
           assert.equal(result.verified, true, 'signature verification failed');
         }).then(done, done);
@@ -1131,7 +1133,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'Ed25519Signature2018',
           creator: testPublicKey.id,
           privateKeyBase58: testPrivateKeyEd25519Base58,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }, function(err, signedDocument) {
           assert.ifError(err);
           assert.notEqual(
@@ -1158,7 +1160,7 @@ describe('JSON-LD Signatures', function() {
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
           checkTimestamp: false,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }, function(err, result) {
           assert.ifError(err);
           assert.equal(result.verified, true, 'signature verification failed');
@@ -1236,7 +1238,7 @@ describe('JSON-LD Signatures', function() {
           algorithm: 'Ed25519Signature2018',
           privateKeyBase58: testPrivateKeyEd25519Base58,
           creator: testPublicKey.id,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }).then(function(signedDocument) {
           assert.notEqual(
             signedDocument['https://w3id.org/security#proof'], undefined,
@@ -1260,7 +1262,7 @@ describe('JSON-LD Signatures', function() {
           // timestamp is quite old, do not check it, it is used to ensure
           // a static document is being checked
           checkTimestamp: false,
-          proofPurpose: NoOpProofPurpose,
+          proofPurpose: 'NoOpProofPurpose',
         }).then(function(result) {
           assert.equal(result.verified, true, 'signature verification failed');
         }).then(done, done);

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -78,10 +78,10 @@ class NoOpProofPurpose extends ProofPurpose {
     // TODO: We need a more permanent URI for this.  Where would it go?
     this.uri = noOpPpUri;
   }
-  async verify(document, proof, ppOptions) {
+  async verify(document, proof, proofPurposeOptions) {
     return true;
   }
-  async addFieldsToProof(proof, ppOptions) {
+  async addFieldsToProof(proof, proofPurposeOptions) {
     return proof;
   }
 }


### PR DESCRIPTION
- Add proofPurpose and ppOptions fields to sign/verify procedures.
- Signing with proofPurpose supplied adds specific fields to the
  proof based on the proofPurpose's associated class's
  addFieldsToProof method.
- Verifying with proofPurpose supplied filters to only the fields
  with that proofPurpose and runs an additional check against the
  proofPurpose's verify method.
- Add LinkedDataSignature ProofPurpose as one particularly simple
  ProofPurpose suite.
- Update tests to match this expectation.

The one thing this PR doesn't do yet is update tests to test for the ProofPurpose's `addFieldsToProof` and `verify` methods.  Those would be good to test but I didn't want to hold back submitting this given deadlines.

This is the foundation for ocap-ld.js which will now be separated out.