### PR TITLE
Serialize proof verification errors.

### DIFF
--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -6,6 +6,7 @@
 const constants = require('./constants');
 const jsonld = require('jsonld');
 const {extendContextLoader, strictDocumentLoader} = require('./documentLoader');
+const serializeError = require('serialize-error');
 const strictExpansionMap = require('./expansionMap');
 const PublicKeyProofPurpose = require('./purposes/PublicKeyProofPurpose');
 
@@ -266,6 +267,7 @@ module.exports = class ProofSet {
       }
       return {verified, results};
     } catch(error) {
+      _addToJSON(error);
       return {verified: false, error};
     }
   }
@@ -323,5 +325,25 @@ async function _verify({
           compactProof}).catch(error => ({verified: false, error}));
       }
     }
-  }))).map((r, i) => r ? {proof: matches[i], ...r} : null).filter(r => r);
+  }))).map((r, i) => {
+    if(!r) {
+      return null;
+    }
+    if(r.error) {
+      _addToJSON(r.error);
+    }
+    return {proof: matches[i], ...r};
+  }).filter(r => r);
+}
+
+// add a `toJSON` method to an error which allows for errors in validation
+// reports to be serialized properly by `JSON.stringify`.
+function _addToJSON(error) {
+  Object.defineProperty(error, 'toJSON', {
+    value: function() {
+      return serializeError(this);
+    },
+    configurable: true,
+    writable: true
+  });
 }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "bs58": "^4.0.1",
     "crypto-ld": "^3.0.0",
     "jsonld": "^1.5.1",
-    "node-forge": "^0.8.0"
+    "node-forge": "^0.8.0",
+    "serialize-error": "^4.1.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.3",

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -208,6 +208,11 @@ describe('JSON-LD Signatures', () => {
       assert.ok(result.error);
       assert.equal(result.error.message.includes(
         'no proofs matched the required suite and purpose'), true);
+
+      // errors should be serialized properly in the verification report
+      const {error} = JSON.parse(JSON.stringify(result));
+      assert.typeOf(error, 'object');
+      assert.sameMembers(Object.keys(error), ['name', 'message', 'stack']);
     });
 
     it('should not verify a document with non-matching purpose', async () => {
@@ -225,6 +230,11 @@ describe('JSON-LD Signatures', () => {
       assert.ok(result.error);
       assert.equal(result.error.message.includes(
         'no proofs matched the required suite and purpose'), true);
+
+      // errors should be serialized properly in the verification report
+      const {error} = JSON.parse(JSON.stringify(result));
+      assert.typeOf(error, 'object');
+      assert.sameMembers(Object.keys(error), ['name', 'message', 'stack']);
     });
   });
 
@@ -712,8 +722,7 @@ describe('JSON-LD Signatures', () => {
       });
 
       context('AuthenticationProofPurpose', () => {
-        it('should detect an expired date',
-          async () => {
+        it('should detect an expired date', async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({
             ...mock.suites[suiteName].parameters.sign,
@@ -760,6 +769,14 @@ describe('JSON-LD Signatures', () => {
           assert.equal(
             result.results[0].error.message,
             'The proof\'s created timestamp is out of range.');
+
+          // errors should be serialized properly in the verification report
+          const {error} = JSON.parse(JSON.stringify(result));
+          assert.typeOf(error, 'array');
+          assert.lengthOf(error, 1);
+          const [e] = error;
+          assert.typeOf(e, 'object');
+          assert.sameMembers(Object.keys(e), ['name', 'message', 'stack']);
         });
 
         it('should detect a non-matching challenge',


### PR DESCRIPTION
If you had a failed proof, and you did a `stringify` on the result of `jsigs.verify` error would be `{}`.

Tests are still passing because the tests that make assertions about errors simply verify error properties such as `error.message` which is still available in the json error object.  Which is to say, there is no assertion that the errors are `instanceof Error`.

### before
```
{
  "verified": false,
  "results": [
    {
      "proof": {
        "@context": "https://w3id.org/security/v2",
        "type": "Ed25519Signature2018",
        "created": "2019-04-05T16:45:29Z",
        "capability": "https://example.com/foo",
        "capabilityAction": "WrapKeyOperation",
        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..RkF0TDVSZkJKNGg0WVRCNk5XSEVLdFJIbHowOURtRF92dUJJanJGZk9Ga29jQmt6bEdUeU9HSmpsYnQxTnZHMThrTVJZQV9FN2FydUpZTXJUc2NQQXc",
        "proofPurpose": "capabilityInvocation",
        "verificationMethod": "https://example.com/myPublicKey"
      },
      "verified": false,
      "error": {}
    }
  ],
  "error": [
    {}
  ]
}
```

### after
```
{
  "verified": false,
  "results": [
    {
      "proof": {
        "@context": "https://w3id.org/security/v2",
        "type": "Ed25519Signature2018",
        "created": "2019-04-05T16:45:29Z",
        "capability": "https://example.com/foo",
        "capabilityAction": "WrapKeyOperation",
        "jws": "eyJhbGciOiJFZERTQSIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..RkF0TDVSZkJKNGg0WVRCNk5XSEVLdFJIbHowOURtRF92dUJJanJGZk9Ga29jQmt6bEdUeU9HSmpsYnQxTnZHMThrTVJZQV9FN2FydUpZTXJUc2NQQXc",
        "proofPurpose": "capabilityInvocation",
        "verificationMethod": "https://example.com/myPublicKey"
      },
      "verified": false,
      "error": {
        "name": "Error",
        "message": "Invalid signature.",
        "stack": "Error: Invalid signature.\n    at Ed25519Signature2018.verifyProof (/home/matt/dev/testsign/node_modules/jsonld-signatures/lib/suites/LinkedDataSignature.js:162:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)\n    at Function.Module.runMain (internal/modules/cjs/loader.js:757:11)\n    at startup (internal/bootstrap/node.js:283:19)\n    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)"
      }
    }
  ],
  "error": [
    {
      "name": "Error",
      "message": "Invalid signature.",
      "stack": "Error: Invalid signature.\n    at Ed25519Signature2018.verifyProof (/home/matt/dev/testsign/node_modules/jsonld-signatures/lib/suites/LinkedDataSignature.js:162:15)\n    at process._tickCallback (internal/process/next_tick.js:68:7)\n    at Function.Module.runMain (internal/modules/cjs/loader.js:757:11)\n    at startup (internal/bootstrap/node.js:283:19)\n    at bootstrapNodeJSCore (internal/bootstrap/node.js:622:3)"
    }
  ]
}
```
