### PR TITLE
Make key signer/verifier factories optional.

### DIFF
--- a/lib/suites/JwsLinkedDataSignature.js
+++ b/lib/suites/JwsLinkedDataSignature.js
@@ -52,8 +52,12 @@ module.exports = class JwsLinkedDataSignature extends LinkedDataSignature {
         }
       }
       this.key = key;
-      this.signer = key.signer();
-      this.verifier = key.verifier();
+      if(typeof key.signer === 'function') {
+        this.signer = key.signer();
+      }
+      if(typeof key.verifier === 'function') {
+        this.verifier = key.verifier();
+      }
     }
   }
 
@@ -64,6 +68,9 @@ module.exports = class JwsLinkedDataSignature extends LinkedDataSignature {
    * @returns {Promise<{object}>} the proof containing the signature value.
    */
   async sign({verifyData, proof}) {
+    if(!(this.signer && typeof this.signer.sign === 'function')) {
+      throw new Error('A signer API has not been specified.');
+    }
     // JWS header
     const header = {
       alg: this.alg,


### PR DESCRIPTION
There is an allowance here that `this.verifier` may not be defined:

https://github.com/digitalbazaar/jsonld-signatures/blob/master/lib/suites/JwsLinkedDataSignature.js#L134

However, when using the constructor, it is expected that if a key is passed in as a parameter, that it *must* provide both a `signer` and `verifier` factory:

https://github.com/digitalbazaar/jsonld-signatures/blob/master/lib/suites/JwsLinkedDataSignature.js#L56

If the conditionals in this PR seem appropriate, it will probably be good to add some validation in the sign/verify APIs to ensure proper behavior when `this.signer` or `this.verifier` are undefined.