### PR TITLE
Use crypto-ld v3.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "base64url": "^3.0.1",
     "bitcore-message": "github:CoMakery/bitcore-message#dist",
     "bs58": "^4.0.1",
-    "crypto-ld": "^3.5.2",
+    "crypto-ld": "^3.5.3",
     "jsonld": "^1.6.2",
     "node-forge": "^0.8.3",
     "security-context": "^3.0.1",


### PR DESCRIPTION
Use crypto-ld@3.5.3 which properly specifies the Node.js engine.