### PR TITLE
Node 12 and JwsLinkedDataSignature export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # jsonld-signatures ChangeLog
 
+### 4.4.0 - TBD
+
+### Added
+- Export `JwsLinkedDataSignature` in suites.
+
+### Changed
+- Use crypto-ld@3.7.0 with support for Node 12 native Ed25519 crypto.
+
 ### 4.3.0 - 2019-09-03
 
 ### Changed

--- a/lib/suites.js
+++ b/lib/suites.js
@@ -10,6 +10,7 @@ module.exports = api;
 api.suites = {
   EcdsaKoblitzSignature2016: require('./suites/EcdsaKoblitzSignature2016'),
   Ed25519Signature2018: require('./suites/Ed25519Signature2018'),
+  JwsLinkedDataSignature: require('./suites/JwsLinkedDataSignature'),
   LinkedDataProof: require('./suites/LinkedDataProof'),
   LinkedDataSignature: require('./suites/LinkedDataSignature'),
   LinkedDataSignature2015: require('./suites/LinkedDataSignature2015'),

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "base64url": "^3.0.1",
     "bitcore-message": "github:CoMakery/bitcore-message#dist",
     "bs58": "^4.0.1",
-    "crypto-ld": "^3.5.3",
+    "crypto-ld": "^3.7.0",
     "jsonld": "^1.6.2",
     "node-forge": "^0.8.3",
     "security-context": "^4.0.0",


### PR DESCRIPTION
New export for JwsLinkedDataSignature is in support of ecdsa-secp256k1-signature-2019 which is currently using this dev branch: https://github.com/digitalbazaar/ecdsa-secp256k1-signature-2019/blob/master/lib/index.js#L7