### PR TITLE
Issue 89 overwritten controller

### DIFF
--- a/lib/purposes/ControllerProofPurpose.js
+++ b/lib/purposes/ControllerProofPurpose.js
@@ -55,8 +55,9 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
           } else if(typeof controller !== 'string') {
             throw new TypeError(
               '"controller" must be a string representing a URL.');
+          } else {
+            controllerId = controller;
           }
-          controllerId = controller;
         } else if(owner) {
           if(typeof owner === 'object') {
             controllerId = owner.id;
@@ -66,7 +67,6 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
           }
           controllerId = owner;
         }
-
         // Note: `expansionMap` is intentionally not passed; we can safely drop
         // properties here and must allow for it
         const {'@graph': [framed = {}]} = await jsonld.frame(controllerId, {

--- a/lib/purposes/ControllerProofPurpose.js
+++ b/lib/purposes/ControllerProofPurpose.js
@@ -46,7 +46,6 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
       if(this.controller) {
         result.controller = this.controller;
       } else {
-        // support legacy `owner` property
         const {controller, owner} = verificationMethod;
         let controllerId;
         if(controller) {
@@ -58,6 +57,7 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
           } else {
             controllerId = controller;
           }
+        // support legacy `owner` property
         } else if(owner) {
           if(typeof owner === 'object') {
             controllerId = owner.id;

--- a/lib/purposes/ControllerProofPurpose.js
+++ b/lib/purposes/ControllerProofPurpose.js
@@ -46,6 +46,7 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
       if(this.controller) {
         result.controller = this.controller;
       } else {
+        // support legacy `owner` property
         const {controller, owner} = verificationMethod;
         let controllerId;
         if(controller) {
@@ -57,7 +58,6 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
           } else {
             controllerId = controller;
           }
-        // support legacy `owner` property
         } else if(owner) {
           if(typeof owner === 'object') {
             controllerId = owner.id;
@@ -80,7 +80,6 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
         }, {documentLoader, compactToRelative: false});
         result.controller = framed;
       }
-
       const verificationMethods = jsonld.getValues(
         result.controller, this.term);
       result.valid = verificationMethods.some(vm =>

--- a/lib/purposes/ControllerProofPurpose.js
+++ b/lib/purposes/ControllerProofPurpose.js
@@ -73,6 +73,8 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
         const {'@graph': [framed = {}]} = await jsonld.frame(controllerId, {
           '@context': constants.SECURITY_CONTEXT_URL,
           id: controllerId,
+          // the term should be in the json-ld object the controllerId resolves
+          // to.
           [this.term]: {
             '@embed': '@never',
             id: verificationId

--- a/lib/purposes/ControllerProofPurpose.js
+++ b/lib/purposes/ControllerProofPurpose.js
@@ -64,8 +64,9 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
           } else if(typeof owner !== 'string') {
             throw new TypeError(
               '"owner" must be a string representing a URL.');
+          } else {
+            controllerId = owner;
           }
-          controllerId = owner;
         }
         // Note: `expansionMap` is intentionally not passed; we can safely drop
         // properties here and must allow for it

--- a/tests/mock/Ed25519Signature2018.js
+++ b/tests/mock/Ed25519Signature2018.js
@@ -78,8 +78,8 @@ mock.parameters.sign = {
   })
 };
 
-// this links back to a key with an assertionMethod on it
-mock.parameters.assertionMethod = {
+// this links back to a key with a controller object
+mock.parameters.controllerObject = {
   creator: publicKeys.ned.id,
   date: '2018-02-13T21:26:08Z',
   key: new Ed25519KeyPair({

--- a/tests/mock/Ed25519Signature2018.js
+++ b/tests/mock/Ed25519Signature2018.js
@@ -78,6 +78,16 @@ mock.parameters.sign = {
   })
 };
 
+// this links back to a key with an assertionMethod on it
+mock.parameters.assertionMethod = {
+  creator: publicKeys.ned.id,
+  date: '2018-02-13T21:26:08Z',
+  key: new Ed25519KeyPair({
+    privateKeyBase58: privateKeys.ned.privateKeyBase58,
+    ...publicKeys.ned
+  })
+};
+
 mock.parameters.verify = {
   creator: publicKeys.carol.id,
   date: '2018-02-13T21:26:08Z'

--- a/tests/mock/RsaSignature2018.js
+++ b/tests/mock/RsaSignature2018.js
@@ -90,8 +90,8 @@ mock.parameters.sign = {
   })
 };
 
-// this links back to a key with an assertionMethod on it
-mock.parameters.assertionMethod = {
+// this links back to a key with a controller object
+mock.parameters.controllerObject = {
   creator: publicKeys.alex.id,
   date: '2018-02-13T21:26:08Z',
   key: new RSAKeyPair({

--- a/tests/mock/RsaSignature2018.js
+++ b/tests/mock/RsaSignature2018.js
@@ -90,6 +90,15 @@ mock.parameters.sign = {
   })
 };
 
+// this links back to a key with an assertionMethod on it
+mock.parameters.assertionMethod = {
+  creator: publicKeys.alex.id,
+  date: '2018-02-13T21:26:08Z',
+  key: new RSAKeyPair({
+    privateKeyPem: privateKeys.alex.privateKeyPem,
+    ...publicKeys.alex
+  })
+};
 mock.parameters.verify = {
   creator: publicKeys.alice.id,
   date: '2018-02-22T15:16:04Z'

--- a/tests/mock/keys.js
+++ b/tests/mock/keys.js
@@ -110,7 +110,8 @@ publicKeys.alex = {
   '@context': constants.SECURITY_CONTEXT_URL,
   id: 'https://example.com/i/alex/keys/1',
   type: ['RsaVerificationKey2018'],
-  controller: 'https://example.com/i/alex',
+  // this test ensures that controller.id works
+  controller: {id: 'https://example.com/i/alex'},
   publicKeyPem: '-----BEGIN PUBLIC KEY-----\r\n' +
     'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0MG729HDdieuzyFT+vdg\r\n' +
     'MXDjTdCniWv64evMXydjfaYlTsmd1FfFQYJdrKJaFzB4y9vm37yKvsw7FJFymSzm\r\n' +
@@ -124,7 +125,7 @@ publicKeys.alex = {
 // RsaKey with an assertionMethod
 controllers.alex = {
   '@context': constants.SECURITY_CONTEXT_URL,
-  id: publicKeys.alex.controller,
+  id: publicKeys.alex.controller.id,
   assertionMethod: [publicKeys.alex.id],
   publicKey: [publicKeys.alex]
 };
@@ -258,7 +259,8 @@ publicKeys.ned = {
   '@context': constants.SECURITY_CONTEXT_URL,
   id: 'https://example.com/i/ned/keys/1',
   type: ['Ed25519VerificationKey2018'],
-  controller: 'https://example.com/i/ned',
+  // this test ensures that controller.id works
+  controller: {id: 'https://example.com/i/ned'},
   publicKeyBase58: '39GT26rnBupnnwBhwqHxsCgqoMNYauRStTQCN5JNaPL7'
 };
 
@@ -272,7 +274,7 @@ privateKeys.ned = {
 // that's publicKey is in the Ed25519 format.
 controllers.ned = {
   '@context': constants.SECURITY_CONTEXT_URL,
-  id: publicKeys.ned.controller,
+  id: publicKeys.ned.controller.id,
   assertionMethod: [publicKeys.ned.id],
   publicKey: [publicKeys.ned]
 };

--- a/tests/mock/keys.js
+++ b/tests/mock/keys.js
@@ -76,6 +76,59 @@ controllers.alice = {
   }
 };
 
+privateKeys.alex = {
+  privateKeyPem: '-----BEGIN RSA PRIVATE KEY-----\r\n' +
+   'MIIEpQIBAAKCAQEA0MG729HDdieuzyFT+vdgMXDjTdCniWv64evMXydjfaYlTsmd\r\n' +
+   '1FfFQYJdrKJaFzB4y9vm37yKvsw7FJFymSzmk4T62yMqCIe19UNGHqk5TDVSKf0X\r\n' +
+   'ZTZX+5i9qhQOaL7yFzzLunI8bNxAzJZ63cGWf4uJI+513SN9IKvh45vWlgsbZ/ek\r\n' +
+   'ELHF0YXrupeTzQZMq4fl2/vQxPPmpooNXZ3Fud9DZLAyWhKg69u996XjYP0QcjkE\r\n' +
+   '7H1PC1Um+CYDGe65pzBQlYlwgYtztK64kK3A2FGVQufyQ+19FlHTJTYdyy/zKtyE\r\n' +
+   '2+22wuANiLkg9JQEWroRQaGBLCmjwaA+AMQmfQIDAQABAoIBAQCezfIZy93UgWWS\r\n' +
+   '/jiDnzHXCphv9r2sZa9Js/YZoL4ntH+HCwr8oPRW3FRkYnEEWQRbmGJua2Bkurpq\r\n' +
+   '8CZsbeLN8AhhMcPlD1AVTuMFqhgDaECj3nuwrAGMTOpjerRnbHJ/yOj2Ybaj3X2R\r\n' +
+   '5Rt8nKrfRgfChMG2wyuJ8hd57W/1XQf0l5Zn3kdRBK5NzUp9fRBJxFEKag8z+Zij\r\n' +
+   'X4ENJmR66gCNLlE87+XMhcyHoJJmmhijC1Hq5Ph4rAsHKN6AMWviW59EyViA2gAb\r\n' +
+   'iwwNlmg0W9qYxsbcrApJo/PAncCiNLvOshr8CwCdY1k9WOvAxPgBtAtEEXoH/01r\r\n' +
+   'SJQ/wSElAoGBAOlUoOn2CQztW+Wm9yyRXGjYxl5a/3Nn3JHCAKj37KX+4aknoIv2\r\n' +
+   'LckuA6pJCbW1Q8VVP8OH1lj43wb3siHzmH2jM6f0GIbSVFn/Z0mfhSGHGRHOuJXK\r\n' +
+   'AXurraSIoPKi5G1ZhMNQB8RBq/Os1LrRCJ9L8pWDQHhsGT9PIp9q7fGLAoGBAOUJ\r\n' +
+   '6Ig/RG/V7NRfoqP8Lupi820Q0EdLL9Jnr6utKtPxaGFSi9MrmCJK+9YD1VWw9XZ8\r\n' +
+   'pFxIkz8aNRPnJgAWT66SLLPiW7wsQezLqpcWprsvfpbusPpfMf6K7FSWHYJJVL1i\r\n' +
+   'pS/MBdeDgl/DBJgfm4OrIuuodaKFvC7jJnUEQrkXAoGBAMPykzQHr7AQgVVKM1dV\r\n' +
+   'N5LBQU2qA87qERzDHITJuA3rD51brwL7GZZSszdFIQddE23b2rGdGNAdKEcUqp7C\r\n' +
+   'kHQqI05Pum02oyn1R8tXUJlIeDAxN2hrfXVbRnbfWrKJQ2XlgI35XpxdPkdkBD5j\r\n' +
+   'H2ePg0g2MmUu+sDk90GDrhFjAoGBAIS//m/hw6fSZScemyTSyNp/KbogUafQ01Hv\r\n' +
+   'WOl3P+iB9k7aSkLF9LKDpX2A0UiOfWcEjTsTsYyUgwkbI3JPfDWhcZl9bFAfksJN\r\n' +
+   'tX1G2rKJr6SJijhDrrVrDdlk/IuEN0Jhh36xkP09svYQEXyebUOekGnoRO5C9zRx\r\n' +
+   '4dtW8dlXAoGAZe/1usB8YV7fOdGCJJ/IBLXG5xbtoSVD8yM/HVllazfr6fKlGqPO\r\n' +
+   'ORhqr5estS7IVwZjcArkqiwJeXXUYPt0m9Oasqf1+g3UibR2SFRs1ZCLq1hSIuwf\r\n' +
+   '4/MYqzY1568+/4+QkLFkjdT18HbkL7cRZrYmAoonb1KeDEbh0THsFHw=\r\n' +
+   '-----END RSA PRIVATE KEY-----\r\n'
+};
+
+publicKeys.alex = {
+  '@context': constants.SECURITY_CONTEXT_URL,
+  id: 'https://example.com/i/alex/keys/1',
+  type: ['RsaVerificationKey2018'],
+  controller: 'https://example.com/i/alex',
+  publicKeyPem: '-----BEGIN PUBLIC KEY-----\r\n' +
+    'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA0MG729HDdieuzyFT+vdg\r\n' +
+    'MXDjTdCniWv64evMXydjfaYlTsmd1FfFQYJdrKJaFzB4y9vm37yKvsw7FJFymSzm\r\n' +
+    'k4T62yMqCIe19UNGHqk5TDVSKf0XZTZX+5i9qhQOaL7yFzzLunI8bNxAzJZ63cGW\r\n' +
+    'f4uJI+513SN9IKvh45vWlgsbZ/ekELHF0YXrupeTzQZMq4fl2/vQxPPmpooNXZ3F\r\n' +
+    'ud9DZLAyWhKg69u996XjYP0QcjkE7H1PC1Um+CYDGe65pzBQlYlwgYtztK64kK3A\r\n' +
+    '2FGVQufyQ+19FlHTJTYdyy/zKtyE2+22wuANiLkg9JQEWroRQaGBLCmjwaA+AMQm\r\n' +
+    'fQIDAQAB\r\n-----END PUBLIC KEY-----\r\n'
+};
+
+// RsaKey with an assertionMethod
+controllers.alex = {
+  '@context': constants.SECURITY_CONTEXT_URL,
+  id: publicKeys.alex.controller,
+  assertionMethod: [publicKeys.alex.id],
+  publicKey: [publicKeys.alex]
+};
+
 publicKeys.bob = {
   '@context': constants.SECURITY_CONTEXT_URL,
   id: 'https://example.com/i/bob/keys/1',
@@ -199,4 +252,27 @@ controllers.carol = {
   'https://example.org/special-authentication': {
     publicKey: publicKeys.carol.id
   }
+};
+
+publicKeys.ned = {
+  '@context': constants.SECURITY_CONTEXT_URL,
+  id: 'https://example.com/i/ned/keys/1',
+  type: ['Ed25519VerificationKey2018'],
+  controller: 'https://example.com/i/ned',
+  publicKeyBase58: '39GT26rnBupnnwBhwqHxsCgqoMNYauRStTQCN5JNaPL7'
+};
+
+privateKeys.ned = {
+  privateKeyBase58:
+   '4EyMEq4hqVznTz1uNiuubvC4zach1G2mKMoeWdeN37jvTvCwinrmcBgyoJsgheC9oG' +
+   'uVYVntB4K8ePdmyMfH12vX'
+};
+
+// controller with an assertionMethod on it
+// that's publicKey is in the Ed25519 format.
+controllers.ned = {
+  '@context': constants.SECURITY_CONTEXT_URL,
+  id: publicKeys.ned.controller,
+  assertionMethod: [publicKeys.ned.id],
+  publicKey: [publicKeys.ned]
 };

--- a/tests/mock/keys.js
+++ b/tests/mock/keys.js
@@ -127,6 +127,7 @@ controllers.alex = {
   '@context': constants.SECURITY_CONTEXT_URL,
   id: publicKeys.alex.controller.id,
   assertionMethod: [publicKeys.alex.id],
+  authentication: [publicKeys.alex.id],
   publicKey: [publicKeys.alex]
 };
 
@@ -276,5 +277,6 @@ controllers.ned = {
   '@context': constants.SECURITY_CONTEXT_URL,
   id: publicKeys.ned.controller.id,
   assertionMethod: [publicKeys.ned.id],
+  authentication: [publicKeys.ned.id],
   publicKey: [publicKeys.ned]
 };

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -1008,7 +1008,7 @@ describe('JSON-LD Signatures', () => {
           };
           assert.deepEqual(result, expected);
         });
-        it('should sign and verify with out a controller passed to purpose',
+        it('should sign and verify without a controller passed to purpose',
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -1008,7 +1008,7 @@ describe('JSON-LD Signatures', () => {
           };
           assert.deepEqual(result, expected);
         });
-        it('should sign and verify with out a controller',
+        it('should sign and verify with out a controller passed to purpose',
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({
@@ -1180,7 +1180,7 @@ describe('JSON-LD Signatures', () => {
           assert.deepEqual(result, expected);
         });
 
-        it('should sign and verify with out a controller',
+        it('should sign and verify with out a controller passed to purpose',
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -8,10 +8,14 @@ module.exports = async function(options) {
 
 const {assert, constants, jsigs, mock, suites, util} = options;
 const {
-  AssertionProofPurpose, AuthenticationProofPurpose,
-  PublicKeyProofPurpose} = jsigs.purposes;
+  AssertionProofPurpose,
+  AuthenticationProofPurpose,
+  ControllerProofPurpose,
+  PublicKeyProofPurpose
+} = jsigs.purposes;
 const {LinkedDataProof} = jsigs.suites;
 const {NoOpProofPurpose} = mock;
+const {extendContextLoader} = jsigs;
 
 // helper:
 function clone(obj) {
@@ -1138,6 +1142,35 @@ describe('JSON-LD Signatures', () => {
       });
     });
   }
+  context('ControllerProofPurpose', async () => {
+    context('should validate', () => {
+      it('a verificationMethod with a controller object', async () => {
+        const purpose = new ControllerProofPurpose({term: 'publicKey'});
+        const verificationMethod = {
+          id: 'https://example.com/i/alice/keys/1',
+          type: 'RsaVerificationKey2018',
+          owner: 'https://example.com/i/alice/keys/1',
+          controller: {
+            id: 'https://example.com/i/alice'
+          },
+          publicKeyPem: ''
+        };
+        const proof = {
+          '@context': 'https://w3id.org/security/v2',
+          type: 'RsaSignature2018',
+          created: new Date().toISOString(),
+          creator: 'https://example.com/i/alice/keys/1',
+          proofPurpose: 'assertionMethod',
+        };
+        const result = await purpose.validate(proof, {
+          verificationMethod,
+          documentLoader: extendContextLoader(testLoader),
+        });
+        assert.exists(result);
+        assert.equal(result.valid, true);
+      });
+    });
+  });
 });
 
 };

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -140,34 +140,6 @@ describe('JSON-LD Signatures', () => {
     });
   });
 
-  context('PublicKeyProofPurpose', async () => {
-    it('should validate a verificationMethod with a ' +
-      'controller object', async () => {
-      const purpose = new PublicKeyProofPurpose();
-      const verificationMethod = {
-        '@context': 'https://w3id.org/security/v2',
-        id: 'https://example.com/i/alice/keys/1',
-        type: 'RsaVerificationKey2018',
-        controller: {
-          id: 'https://example.com/i/alice'
-        },
-        publicKeyPem: ''
-      };
-      const proof = {
-        '@context': 'https://w3id.org/security/v2',
-        type: 'RsaSignature2018',
-        created: new Date().toISOString(),
-        creator: 'https://example.com/i/alice/keys/1',
-      };
-      const result = await purpose.validate(proof, {
-        verificationMethod,
-        documentLoader: extendContextLoader(testLoader),
-      });
-      assert.exists(result);
-      assert.equal(result.valid, true);
-    });
-  });
-
   context('custom suite', () => {
     class CustomSuite extends LinkedDataProof {
       constructor({match = true} = {}) {

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -1180,7 +1180,7 @@ describe('JSON-LD Signatures', () => {
           assert.deepEqual(result, expected);
         });
 
-        it('should sign and verify with out a controller passed to purpose',
+        it('should sign and verify without a controller passed to purpose',
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -140,7 +140,6 @@ describe('JSON-LD Signatures', () => {
     });
   });
 
-/**
   context('PublicKeyProofPurpose', async () => {
     it('should validate a verificationMethod with a ' +
       'controller object', async () => {
@@ -168,7 +167,7 @@ describe('JSON-LD Signatures', () => {
       assert.equal(result.valid, true);
     });
   });
-*/
+
   context('custom suite', () => {
     class CustomSuite extends LinkedDataProof {
       constructor({match = true} = {}) {
@@ -1172,7 +1171,7 @@ describe('JSON-LD Signatures', () => {
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({
-            ...mock.suites[suiteName].parameters.sign,
+            ...mock.suites[suiteName].parameters.assertionMethod,
             date: new Date('01-01-1970')
           });
           const testDoc = clone(mock.securityContextTestDoc);

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -10,7 +10,6 @@ const {assert, constants, jsigs, mock, suites, util} = options;
 const {
   AssertionProofPurpose,
   AuthenticationProofPurpose,
-  ControllerProofPurpose,
   PublicKeyProofPurpose
 } = jsigs.purposes;
 const {LinkedDataProof} = jsigs.suites;
@@ -138,6 +137,33 @@ describe('JSON-LD Signatures', () => {
       }
       assert.exists(err);
       assert.equal(err.message, '"options.purpose" is required.');
+    });
+  });
+
+  context('PublicKeyProofPurpose', async () => {
+    it('should validate a verificationMethod with a ' +
+      'controller object', async () => {
+      const purpose = new PublicKeyProofPurpose();
+      const verificationMethod = {
+        id: 'https://example.com/i/alice/keys/1',
+        type: 'RsaVerificationKey2018',
+        controller: {
+          id: 'https://example.com/i/alice'
+        },
+        publicKeyPem: ''
+      };
+      const proof = {
+        '@context': 'https://w3id.org/security/v2',
+        type: 'RsaSignature2018',
+        created: new Date().toISOString(),
+        creator: 'https://example.com/i/alice/keys/1',
+      };
+      const result = await purpose.validate(proof, {
+        verificationMethod,
+        documentLoader: extendContextLoader(testLoader),
+      });
+      assert.exists(result);
+      assert.equal(result.valid, true);
     });
   });
 
@@ -1142,35 +1168,5 @@ describe('JSON-LD Signatures', () => {
       });
     });
   }
-  context('ControllerProofPurpose', async () => {
-    context('should validate', () => {
-      it('a verificationMethod with a controller object', async () => {
-        const purpose = new ControllerProofPurpose({term: 'publicKey'});
-        const verificationMethod = {
-          id: 'https://example.com/i/alice/keys/1',
-          type: 'RsaVerificationKey2018',
-          owner: 'https://example.com/i/alice/keys/1',
-          controller: {
-            id: 'https://example.com/i/alice'
-          },
-          publicKeyPem: ''
-        };
-        const proof = {
-          '@context': 'https://w3id.org/security/v2',
-          type: 'RsaSignature2018',
-          created: new Date().toISOString(),
-          creator: 'https://example.com/i/alice/keys/1',
-          proofPurpose: 'assertionMethod',
-        };
-        const result = await purpose.validate(proof, {
-          verificationMethod,
-          documentLoader: extendContextLoader(testLoader),
-        });
-        assert.exists(result);
-        assert.equal(result.valid, true);
-      });
-    });
   });
-});
-
 };

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -1012,7 +1012,7 @@ describe('JSON-LD Signatures', () => {
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({
-            ...mock.suites[suiteName].parameters.assertionMethod,
+            ...mock.suites[suiteName].parameters.controllerObject,
             date: new Date('01-01-1970')
           });
           const testDoc = clone(mock.securityContextTestDoc);
@@ -1184,7 +1184,7 @@ describe('JSON-LD Signatures', () => {
           async () => {
           const Suite = suites[suiteName];
           const signSuite = new Suite({
-            ...mock.suites[suiteName].parameters.assertionMethod,
+            ...mock.suites[suiteName].parameters.controllerObject,
             date: new Date('01-01-1970')
           });
           const testDoc = clone(mock.securityContextTestDoc);


### PR DESCRIPTION
This corrects https://github.com/digitalbazaar/jsonld-signatures/issues/89

using the fixed suggested by @gjgd

Adds 4 new tests and 2 new keys.

```
--------------------------------|----------|----------|----------|----------|-------------------|
File                            |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
--------------------------------|----------|----------|----------|----------|-------------------|
All files                       |     79.9 |    65.77 |    85.57 |    79.64 |                   |
 lib                            |    74.09 |    62.31 |    78.72 |    73.41 |                   |
  ProofSet.js                   |    91.74 |    76.47 |    94.74 |     91.3 |... 29,238,330,335 |
  constants.js                  |      100 |      100 |      100 |      100 |                   |
  contexts.js                   |      100 |      100 |      100 |      100 |                   |
  documentLoader.js             |    90.91 |      100 |    66.67 |    90.91 |                66 |
  env.js                        |      100 |    66.67 |      100 |      100 |                 9 |
  expansionMap.js               |    66.67 |       50 |      100 |    66.67 |                 9 |
  jsonld-signatures.js          |    64.29 |    58.33 |      100 |    64.29 |... 41,42,43,46,47 |
  purposes.js                   |      100 |      100 |      100 |      100 |                   |
  suites.js                     |      100 |      100 |      100 |      100 |                   |
  util.js                       |    49.48 |     37.5 |    63.64 |    48.96 |... 23,225,227,228 |
 lib/purposes                   |    88.89 |    72.86 |      100 |    88.89 |                   |
  AssertionProofPurpose.js      |      100 |      100 |      100 |      100 |                   |
  AuthenticationProofPurpose.js |    90.48 |    76.47 |      100 |    90.48 |             15,18 |
  ControllerProofPurpose.js     |    86.84 |    64.29 |      100 |    86.84 |    29,54,56,63,65 |
  ProofPurpose.js               |    86.96 |       75 |      100 |    86.96 |          17,21,27 |
  PublicKeyProofPurpose.js      |      100 |      100 |      100 |      100 |                   |
 lib/suites                     |    82.95 |    65.44 |    88.89 |    82.88 |                   |
  EcdsaKoblitzSignature2016.js  |     91.3 |    57.14 |      100 |     91.3 |             23,45 |
  Ed25519Signature2018.js       |      100 |      100 |      100 |      100 |                   |
  GraphSignature2012.js         |     87.5 |    66.67 |      100 |     87.5 |             48,53 |
  JwsLinkedDataSignature.js     |    83.33 |    70.45 |      100 |    83.33 |... 26,133,169,182 |
  LinkedDataProof.js            |    57.14 |    33.33 |       50 |    57.14 |           9,25,38 |
  LinkedDataSignature.js        |    84.93 |    61.54 |       80 |    84.93 |... 58,263,279,293 |
  LinkedDataSignature2015.js    |    76.81 |    68.75 |      100 |    76.47 |... 65,166,167,171 |
  RsaSignature2018.js           |      100 |        0 |      100 |      100 |                32 |
--------------------------------|----------|----------|----------|----------|-------------------|
```

Expands test coverage of purposes by 3%.