### PR TITLE
Wrap multiple verify() errors in an umbrella error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
   - Remove bitcore-message dependency.
   - Move feature to 'ecdsa-koblitz-signature-2016' package.
 
+### Changed
+  - **BREAKING**: `verify()`'s results.error is now always a 
+  `VerificationError` instance where `error.errors` is an array that includes 
+  all of the errors that occurred during the verification process.
+
 ### 4.6.0 - 2020-01-17
 
 ### Changed

--- a/lib/VerificationError.js
+++ b/lib/VerificationError.js
@@ -1,0 +1,20 @@
+/*!
+ * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict'
+
+/**
+ * Used as an umbrella wrapper around multiple verification errors.
+ */
+class VerificationError extends Error {
+  /**
+   * @param {Error|Error[]} errors
+   */
+  constructor(errors) {
+    super('Verification error(s).');
+
+    this.name = 'VerificationError';
+    this.errors = [].concat(errors);
+  }
+}
+module.exports = VerificationError;

--- a/lib/jsonld-signatures.js
+++ b/lib/jsonld-signatures.js
@@ -13,6 +13,7 @@ Object.assign(api, constants);
 
 // TODO: support `ProofChain`
 const ProofSet = require('./ProofSet');
+const VerificationError = require('./VerificationError');
 
 api.sign = async function sign(document, {
   suite, purpose, documentLoader, expansionMap, compactProof} = {}) {
@@ -36,15 +37,16 @@ api.verify = async function verify(document, {
   suite, purpose, documentLoader, expansionMap, compactProof} = {}) {
   const result = await new ProofSet().verify(
     document, {suite, purpose, documentLoader, expansionMap, compactProof});
-  if(!documentLoader && result.error) {
-    const {error} = result;
-    if(error.name === 'jsonld.InvalidUrl') {
+  const {error} = result;
+  if(error) {
+    if(!documentLoader && error.name === 'jsonld.InvalidUrl') {
       const {details: {url}} = error;
-      const err = new Error(
+      const urlError = new Error(
         `A URL "${url}" could not be fetched; you need to pass ` +
         '"documentLoader" or resolve the URL before calling "verify".');
-      err.cause = error;
-      result.error = err;
+      result.error = new VerificationError(urlError);
+    } else {
+      result.error = new VerificationError(error);
     }
   }
   return result;

--- a/tests/test-common.js
+++ b/tests/test-common.js
@@ -241,13 +241,15 @@ describe('JSON-LD Signatures', () => {
       });
       assert.equal(result.verified, false);
       assert.ok(result.error);
-      assert.equal(result.error.message.includes(
+      assert.equal(result.error.name, 'VerificationError');
+
+      assert.equal(result.error.errors[0].message.includes(
         'no proofs matched the required suite and purpose'), true);
 
       // errors should be serialized properly in the verification report
       const {error} = JSON.parse(JSON.stringify(result));
       assert.typeOf(error, 'object');
-      assert.sameMembers(Object.keys(error), ['name', 'message', 'stack']);
+      assert.sameMembers(Object.keys(error), ['name', 'errors']);
     });
 
     it('should not verify a document with non-matching purpose', async () => {
@@ -263,13 +265,13 @@ describe('JSON-LD Signatures', () => {
       });
       assert.equal(result.verified, false);
       assert.ok(result.error);
-      assert.equal(result.error.message.includes(
+      assert.equal(result.error.errors[0].message.includes(
         'no proofs matched the required suite and purpose'), true);
 
       // errors should be serialized properly in the verification report
       const {error} = JSON.parse(JSON.stringify(result));
       assert.typeOf(error, 'object');
-      assert.sameMembers(Object.keys(error), ['name', 'message', 'stack']);
+      assert.sameMembers(Object.keys(error), ['name', 'errors']);
     });
   });
 
@@ -1104,11 +1106,8 @@ describe('JSON-LD Signatures', () => {
 
           // errors should be serialized properly in the verification report
           const {error} = JSON.parse(JSON.stringify(result));
-          assert.typeOf(error, 'array');
-          assert.lengthOf(error, 1);
-          const [e] = error;
-          assert.typeOf(e, 'object');
-          assert.sameMembers(Object.keys(e), ['name', 'message', 'stack']);
+          assert.typeOf(error, 'object');
+          assert.sameMembers(Object.keys(error), ['name', 'errors']);
         });
 
         it('should detect a non-matching challenge', async () => {


### PR DESCRIPTION
This PR ensures that verify's result.error always contains just one error.
In the case of multiple errors, they're wrapped in a top-level error (and the actual list is contained in error.cause).