### PR TITLE
Drop support for Node 8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ script:
 matrix:
   include:
   - name: "Browser Unit Tests (webpack)"
-    node_js: "12"
+    node_js: "14"
     env: BUNDLER=webpack
   - name: "Browser Unit Tests (browserify)"
-    node_js: "12"
+    node_js: "14"
     env: BUNDLER=browserify
 notifications:
   email:

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-merge": "^4.2.2"
   },
   "engines": {
-    "node": ">=8"
+    "node": ">=10"
   },
   "keywords": [
     "JSON",


### PR DESCRIPTION
CI is failing on this PR because evidently sodium-native (by way of crypto-ld) no longer builds on node 8.  https://github.com/digitalbazaar/jsonld-signatures/pull/113

I am aware there is work on this branch that updates to crypto-ld@4 which l believe addresses this issue as well by eliminating the sodium-native dependency: https://github.com/digitalbazaar/jsonld-signatures/tree/v6.x

It would be good to get a release out that includes the node_forge update referenced in the security alert.

