### PR TITLE
Use the document's context for proof before security context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # jsonld-signatures ChangeLog
 
+## 8.0.2 - 
+
+### Changed
+- In ProofSet, use the document's context for proof before defaulting to 
+  security context.
+
 ## 8.0.1 - 2021-03-18
 
 ### Changed

--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -200,11 +200,10 @@ async function _getProofs({document}) {
     throw new Error('No matching proofs found in the given document.');
   }
 
-  // TODO: consider in-place editing to optimize
-
-  // shallow copy proofs and add SECURITY_CONTEXT_URL
+  // shallow copy proofs and add document context or SECURITY_CONTEXT_URL
+  const context = document['@context'] || constants.SECURITY_CONTEXT_URL;
   proofSet = proofSet.map(proof => ({
-    '@context': constants.SECURITY_CONTEXT_URL,
+    '@context': context,
     ...proof
   }));
 

--- a/lib/purposes/ControllerProofPurpose.js
+++ b/lib/purposes/ControllerProofPurpose.js
@@ -74,6 +74,7 @@ module.exports = class ControllerProofPurpose extends ProofPurpose {
             controllerId = controller;
           }
         }
+
         // Note: `expansionMap` is intentionally not passed; we can safely drop
         // properties here and must allow for it
         const framed = await jsonld.frame(controllerId, {

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -20,12 +20,16 @@ module.exports = class LinkedDataSignature extends LinkedDataProof {
    * @param [proof] {object} a JSON-LD document with options to use for
    *   the `proof` node (e.g. any other custom fields can be provided here
    *   using a context different from security-v2).
+   * @typedef {Object} LDKeyPair
+   * @param {LDKeyPair} LDKeyClass - The crypto-ld key type that this suite
+   *   will use to sign/verify signatures.
    * @param [date] {string|Date} signing date to use if not passed.
    * @param [useNativeCanonize] {boolean} true to use a native canonize
    *   algorithm.
    */
   constructor({
-    type, verificationMethod, proof, date, useNativeCanonize} = {}) {
+    type, verificationMethod, proof, LDKeyClass, date, useNativeCanonize
+  } = {}) {
     // validate common options
     if(verificationMethod !== undefined &&
       typeof verificationMethod !== 'string') {
@@ -33,6 +37,7 @@ module.exports = class LinkedDataSignature extends LinkedDataProof {
     }
     super({type});
     this.verificationMethod = verificationMethod;
+    this.LDKeyClass = LDKeyClass;
     this.proof = proof;
     if(date !== undefined) {
       this.date = new Date(date);


### PR DESCRIPTION
Relevant for the 2020 sig suite.