### PR TITLE
Switch to db/security-context, enable React Native.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # jsonld-signatures ChangeLog
 
+## 9.3.1 -
+
+### Changed
+- Update `jsonld` (and `rdf-canonize`) dependency, to enable use with React
+  Native.
+- Switch to `@digitalbazaar/security-context` (more compact, no fs dependency).
+
+
 ## 9.3.0 - 2021-07-10
 
 ### Added

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -3,7 +3,9 @@
  */
 'use strict';
 
-const {constants: securityConstants} = require('security-context');
+const {
+  constants: securityConstants
+} = require('@digitalbazaar/security-context');
 
 module.exports = {
   SECURITY_CONTEXT_URL: securityConstants.SECURITY_CONTEXT_V2_URL,

--- a/lib/contexts.js
+++ b/lib/contexts.js
@@ -4,7 +4,7 @@
 'use strict';
 
 const constants = require('./constants');
-const {contexts: securityContexts} = require('security-context');
+const {contexts: securityContexts} = require('@digitalbazaar/security-context');
 
 module.exports = new Map([
   [constants.SECURITY_CONTEXT_V1_URL,

--- a/lib/sha256digest-reactnative.js
+++ b/lib/sha256digest-reactnative.js
@@ -17,7 +17,7 @@ module.exports = {
   async sha256digest({string}) {
     const bytes = new TextEncoder().encode(string);
     return new Uint8Array(
-      await crypto.subtle.digest('SHA-256', bytes)
+      await crypto.subtle.digest({name: 'SHA-256'}, bytes)
     );
   }
 };

--- a/lib/sha256digest-reactnative.js
+++ b/lib/sha256digest-reactnative.js
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const crypto = require('isomorphic-webcrypto');
+require('fast-text-encoding');
+
+module.exports = {
+  /**
+   * Hashes a string of data using SHA-256.
+   *
+   * @param {string} string - the string to hash.
+   *
+   * @return {Uint8Array} the hash digest.
+   */
+  async sha256digest({string}) {
+    const bytes = new TextEncoder().encode(string);
+    return new Uint8Array(
+      await crypto.subtle.digest('SHA-256', bytes)
+    );
+  }
+};

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "lib/**/*.js"
   ],
   "dependencies": {
-    "jsonld": "^5.0.0",
-    "security-context": "^4.0.0",
+    "@digitalbazaar/security-context": "^1.0.0",
+    "jsonld": "digitalbazaar/jsonld.js#v5.2.1-rc1",
     "serialize-error": "^8.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,9 @@
   ],
   "dependencies": {
     "@digitalbazaar/security-context": "^1.0.0",
-    "jsonld": "digitalbazaar/jsonld.js#v5.2.1-rc1",
+    "fast-text-encoding": "^1.0.3",
+    "isomorphic-webcrypto": "^2.3.8",
+    "jsonld": "digitalbazaar/jsonld.js#v5.2.1-rc2",
     "serialize-error": "^8.0.1"
   },
   "devDependencies": {
@@ -79,6 +81,13 @@
   },
   "browser": {
     "crypto": false,
-    "./lib/sha256digest.js": "./lib/sha256digest-browser.js"
+    "./lib/sha256digest.js": "./lib/sha256digest-browser.js",
+    "fast-text-encoding": false,
+    "isomorphic-webcrypto": false
+  },
+  "react-native": {
+    "crypto": false,
+    "./lib/sha256digest.js": "./lib/sha256digest-reactnative.js",
+    "./lib/sha256digest-browser.js": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@digitalbazaar/security-context": "^1.0.0",
     "fast-text-encoding": "^1.0.3",
     "isomorphic-webcrypto": "^2.3.8",
-    "jsonld": "digitalbazaar/jsonld.js#v5.2.1-rc2",
+    "jsonld": "digitalbazaar/jsonld.js#rn",
     "serialize-error": "^8.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
- Update `jsonld` (and `rdf-canonize`) dependency, to enable use with React 
  Native.
- Switch to `@digitalbazaar/security-context` (more compact, no fs dependency).