### PR TITLE
Support multiple proof purposes in `verify`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # jsonld-signatures ChangeLog
 
+## 9.2.0 - 2021-xx-xx
+
+### Added
+- Support passing multiple purposes in a single verify call.
+- Add `NotFoundError` name to error thrown when there are not enough proofs
+  to match the passed supported suites and purposes during verification.
+  LD suite implementations should not be relying the error message but can
+  rely on the `name` property of the error instead.
+
+### Changed
+- `LinkedDataSignature` no longer calls `purpose.validate`; this function
+  is instead called after `verifyProof()`. This removes the responsibility
+  of calling this function from LD suite implementations and places it in
+  the main verify call from within jsigs instead. LD suites will still be
+  passed a dummy `purpose` in this version for backwards compatibility
+  purposes that will successfully return a promise that resolves to
+  `true` from `purpose.validate()`. Decoupling this from the suites both
+  establishes a better separation of concerns and simplifies LD suites by
+  reducing their responsibilities. LD suites are responsible for returing
+  the `verificationMethod` used in their results so it can be passed to
+  `purpose.validate()`.
+- Add cache for hash of canonicalized document to enable its reuse when
+  verifying multiple proofs on a single document.
+
 ## 9.1.1 - 2021-06-29
 
 ### Fixed
@@ -39,7 +63,7 @@ a patch.
   Increase validation on either key or signer/verifier parameters.
 
 ### Fixed
-- Add missing `signer` and `verifier` parameters to the `LinkedDataSignature` 
+- Add missing `signer` and `verifier` parameters to the `LinkedDataSignature`
   constructor. This issue caused `this.signer` in subclasses to be `undefined`.
 
 ## 8.0.2 - 2021-03-19

--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -320,7 +320,10 @@ async function _matchProofSet({
       continue;
     }
 
-    // next, find the suite that can verify the proof
+    // next, find the suite that can verify the proof; if found, `matched`
+    // will be set to `true` and the proof will be added to `purposeToProofs`
+    // and `proofToSuite` to be processed -- otherwise it will not be; if
+    // no proofs are added for a given purpose, an exception will be thrown
     let matched = false;
     for(const s of suites) {
       // `matchingProofs` is a map of promises that resolve to whether a

--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -146,12 +146,14 @@ module.exports = class ProofSet {
 
       // verify proofs
       const results = await _verify({
-        document, suites, proofSet, purpose, documentLoader, expansionMap
+        document, suites, proofSet, purpose, documentLoader, expansionMap,
       });
       if(results.length === 0) {
-        throw new Error(
-          'Could not verify any proofs; no proofs matched the required ' +
-          'suite and purpose.');
+        const error = new Error(
+          'Did not verify any proofs; insufficient proofs matched the ' +
+          'acceptable suite(s) and required purpose(s).');
+        error.name = 'NotFoundError';
+        throw error;
       }
 
       // combine results
@@ -167,7 +169,7 @@ module.exports = class ProofSet {
       }
       return {verified, results};
     } catch(error) {
-      _addToJSON(error);
+      _makeSerializable(error);
       return {verified: false, error};
     }
   }
@@ -197,38 +199,108 @@ async function _getProofs({document}) {
 async function _verify({
   document, suites, proofSet, purpose, documentLoader, expansionMap
 }) {
-  // filter out matching proofs
-  const result = await Promise.all(proofSet.map(proof =>
-    purpose.match(proof, {document, documentLoader, expansionMap})));
-  const matches = proofSet.filter((value, index) => result[index]);
-  if(matches.length === 0) {
-    // no matches, nothing to verify
+  // map each purpose to at least one proof to verify
+  const purposes = Array.isArray(purpose) ? purpose : [purpose];
+  const purposeToProofs = new Map();
+  const proofToSuite = new Map();
+  const suiteMatchQueue = new Map();
+  await Promise.all(purposes.map(purpose => _matchProofSet({
+    purposeToProofs, proofToSuite, purpose, proofSet, suites,
+    suiteMatchQueue, document, documentLoader, expansionMap
+  })));
+
+  // every purpose must have at least one matching proof or verify will fail
+  if(purposeToProofs.length < purposes.length) {
+    // insufficient proofs to verify, so don't bother verifying any
     return [];
   }
 
-  // verify each matching proof
-  return (await Promise.all(matches.map(async proof => {
-    for(const s of suites) {
-      if(await s.matchProof({proof, document, documentLoader, expansionMap})) {
-        return s.verifyProof({
-          proof, document, purpose, documentLoader, expansionMap
-        }).catch(error => ({verified: false, error}));
+  // verify every proof in `proofToSuite`; these proofs matched a purpose
+  const verifyResults = new Map();
+  await Promise.all([...proofToSuite.entries()].map(async ([proof, suite]) => {
+    let result;
+    try {
+      // create backwards-compatible deferred proof purpose to capture
+      // verification method from old-style suites
+      let vm;
+      const purpose = {
+        async validate(proof, {verificationMethod}) {
+          vm = verificationMethod;
+          return {valid: true};
+        }
+      };
+      const {verified, verificationMethod, error} = await suite.verifyProof({
+        proof, document, purpose, documentLoader, expansionMap
+      });
+      if(!vm) {
+        vm = verificationMethod;
       }
+      result = {proof, verified, verificationMethod: vm, error};
+    } catch(error) {
+      result = {proof, verified: false, error};
     }
-  }))).map((r, i) => {
-    if(!r) {
-      return null;
+
+    if(result.error) {
+      // ensure error is serializable
+      _makeSerializable(result.error);
     }
-    if(r.error) {
-      _addToJSON(r.error);
-    }
-    return {proof: matches[i], ...r};
-  }).filter(r => r);
+
+    verifyResults.set(proof, result);
+  }));
+
+  // validate proof against each purpose that matched it
+  await Promise.all([...purposeToProofs.entries()].map(
+    async ([purpose, proofs]) => {
+      for(const proof of proofs) {
+        const result = verifyResults.get(proof);
+        if(!result.verified) {
+          // if proof was not verified, so not bother validating purpose
+          continue;
+        }
+
+        // validate purpose
+        const {verificationMethod} = result;
+        const suite = proofToSuite.get(proof);
+        let purposeResult;
+        try {
+          purposeResult = await purpose.validate(proof, {
+            document, suite, verificationMethod, documentLoader, expansionMap
+          });
+        } catch(error) {
+          purposeResult = {valid: false, error};
+        }
+
+        // add `purposeResult` to verification result regardless of validity
+        // to ensure that all purposes are represented
+        if(result.purposeResult) {
+          if(Array.isArray(result.purposeResult)) {
+            result.purposeResult.push(purposeResult);
+          } else {
+            result.purposeResult = [result.purposeResult, purposeResult];
+          }
+        } else {
+          result.purposeResult = purposeResult;
+        }
+
+        if(!purposeResult.valid) {
+          // ensure error is serializable
+          _makeSerializable(purposeResult.error);
+
+          // if no top level error set yet, set it
+          if(!result.error) {
+            result.verified = false;
+            result.error = purposeResult.error;
+          }
+        }
+      }
+    }));
+
+  return [...verifyResults.values()];
 }
 
 // add a `toJSON` method to an error which allows for errors in validation
 // reports to be serialized properly by `JSON.stringify`.
-function _addToJSON(error) {
+function _makeSerializable(error) {
   Object.defineProperty(error, 'toJSON', {
     value: function() {
       return serializeError(this);
@@ -236,4 +308,53 @@ function _addToJSON(error) {
     configurable: true,
     writable: true
   });
+}
+
+async function _matchProofSet({
+  purposeToProofs, proofToSuite, purpose, proofSet, suites,
+  suiteMatchQueue, document, documentLoader, expansionMap
+}) {
+  for(const proof of proofSet) {
+    // first check if the proof matches the purpose; if it doesn't continue
+    if(!await purpose.match(proof, {document, documentLoader, expansionMap})) {
+      continue;
+    }
+
+    // next, find the suite that can verify the proof
+    let matched = false;
+    for(const s of suites) {
+      // `matchingProofs` is a map of promises that resolve to whether a
+      // proof matches a suite; multiple purposes and suites may be checked
+      // in parallel so a promise queue is used to prevent duplicate work
+      let matchingProofs = suiteMatchQueue.get(s);
+      if(!matchingProofs) {
+        suiteMatchQueue.set(s, matchingProofs = new Map());
+      }
+      let promise = matchingProofs.get(proof);
+      if(!promise) {
+        promise = s.matchProof({proof, document, documentLoader, expansionMap});
+        matchingProofs.set(proof, promise);
+      }
+      if(await promise) {
+        // found the matching suite for the proof; there should only be one
+        // suite that can verify a particular proof; add the proof to the
+        // map of proofs to be verified along with the matching suite
+        matched = true;
+        proofToSuite.set(proof, s);
+        break;
+      }
+    }
+
+    if(matched) {
+      // note proof was a match for the purpose and an acceptable suite; it
+      // will need to be verified by the suite and then validated against the
+      // purpose
+      const matches = purposeToProofs.get(purpose);
+      if(matches) {
+        matches.push(proof);
+      } else {
+        purposeToProofs.set(purpose, [proof]);
+      }
+    }
+  }
 }

--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -146,7 +146,7 @@ module.exports = class ProofSet {
 
       // verify proofs
       const results = await _verify({
-        document, suites, proofSet, purpose, documentLoader, expansionMap,
+        document, suites, proofSet, purpose, documentLoader, expansionMap
       });
       if(results.length === 0) {
         const error = new Error(

--- a/lib/suites/LinkedDataSignature.js
+++ b/lib/suites/LinkedDataSignature.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -79,6 +79,7 @@ module.exports = class LinkedDataSignature extends LinkedDataProof {
       }
     }
     this.useNativeCanonize = useNativeCanonize;
+    this._hashCache = null;
   }
 
   /**
@@ -160,15 +161,12 @@ module.exports = class LinkedDataSignature extends LinkedDataProof {
   /**
    * @param proof {object} the proof to be verified.
    * @param document {object} the document the proof applies to.
-   * @param purpose {ProofPurpose}
    * @param documentLoader {function}
    * @param expansionMap {function}
    *
    * @returns {Promise<{object}>} Resolves with the verification result.
    */
-  async verifyProof({
-    proof, document, purpose, documentLoader, expansionMap,
-  }) {
+  async verifyProof({proof, document, documentLoader, expansionMap}) {
     try {
       // create data to verify
       const verifyData = await this.createVerifyData(
@@ -186,15 +184,7 @@ module.exports = class LinkedDataSignature extends LinkedDataProof {
         throw new Error('Invalid signature.');
       }
 
-      // ensure proof was performed for a valid purpose
-      const purposeResult = await purpose.validate(
-        proof, {document, suite: this, verificationMethod,
-          documentLoader, expansionMap});
-      if(!purposeResult.valid) {
-        throw purposeResult.error;
-      }
-
-      return {verified: true, purposeResult};
+      return {verified: true, verificationMethod};
     } catch(error) {
       return {verified: false, error};
     }
@@ -236,18 +226,33 @@ module.exports = class LinkedDataSignature extends LinkedDataProof {
    *
    * @returns {Promise<{Uint8Array}>}.
    */
-  async createVerifyData({
-    document, proof, documentLoader, expansionMap}) {
+  async createVerifyData({document, proof, documentLoader, expansionMap}) {
+    // get cached document hash
+    let cachedDocHash;
+    const {_hashCache} = this;
+    if(_hashCache && _hashCache.document === document) {
+      cachedDocHash = _hashCache.hash;
+    } else {
+      this._hashCache = {
+        document,
+        // canonize and hash document
+        hash: cachedDocHash =
+          this.canonize(document, {documentLoader, expansionMap})
+            .then(c14nDocument => sha256digest({string: c14nDocument}))
+      };
+    }
+
+    // await both c14n proof hash and c14n document hash
+    const [proofHash, docHash] = await Promise.all([
+      // canonize and hash proof
+      this.canonizeProof(
+        proof, {document, documentLoader, expansionMap})
+        .then(c14nProofOptions => sha256digest({string: c14nProofOptions})),
+      cachedDocHash
+    ]);
+
     // concatenate hash of c14n proof options and hash of c14n document
-    const c14nProofOptions = await this.canonizeProof(
-      proof, {document, documentLoader, expansionMap});
-    const c14nDocument = await this.canonize(document, {
-      documentLoader,
-      expansionMap
-    });
-    return util.concat(
-      await sha256digest({string: c14nProofOptions}),
-      await sha256digest({string: c14nDocument}));
+    return util.concat(proofHash, docHash);
   }
 
   /**


### PR DESCRIPTION
Includes cache of document c14n hash to avoid duplicate work when verifying multiple proofs against the same document.