### PR TITLE
Use size to get Map purposeToProofs entries length.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # jsonld-signatures ChangeLog
 
+## 9.2.1 - TBD
+
+### Changed
+- Use the method size to get the number of entries in the Map purposeToProofs.
+
 ## 9.2.0 - 2021-07-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## 9.2.1 - TBD
 
-### Changed
-- Use the method size to get the number of entries in the Map purposeToProofs.
+### Fixed
+- Use the `size` method to get the number of entries in the `purposeToProofs` Map.
 
 ## 9.2.0 - 2021-07-02
 

--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -210,7 +210,7 @@ async function _verify({
   })));
 
   // every purpose must have at least one matching proof or verify will fail
-  if(purposeToProofs.length < purposes.length) {
+  if(purposeToProofs.size < purposes.length) {
     // insufficient proofs to verify, so don't bother verifying any
     return [];
   }


### PR DESCRIPTION
Addresses https://github.com/digitalbazaar/jsonld-signatures/issues/150

Corrects a minor issue where `length` was being called on a `Map` that needs `size`