### PR TITLE
Allow `expansionMap` overrides.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # jsonld-signatures ChangeLog
 
+## 9.3.1 - 2021-xx-xx
+
+### Fixed
+- Allow `expansionMap` overrides.
+
 ## 9.3.0 - 2021-07-10
 
 ### Added

--- a/lib/ProofSet.js
+++ b/lib/ProofSet.js
@@ -57,8 +57,10 @@ module.exports = class ProofSet {
     } else {
       documentLoader = strictDocumentLoader;
     }
-    if(expansionMap !== false) {
+    if(expansionMap === undefined) {
       expansionMap = strictExpansionMap;
+    } else if(expansionMap === false) {
+      expansionMap = undefined;
     }
 
     // preprocess document to prepare to remove existing proofs
@@ -130,8 +132,10 @@ module.exports = class ProofSet {
     } else {
       documentLoader = strictDocumentLoader;
     }
-    if(expansionMap !== false) {
+    if(expansionMap === undefined) {
       expansionMap = strictExpansionMap;
+    } else if(expansionMap === false) {
+      expansionMap = undefined;
     }
 
     try {


### PR DESCRIPTION
Fixes https://github.com/digitalbazaar/jsonld-signatures/issues/111.

Unsure where to add tests, (see https://github.com/digitalbazaar/jsonld-signatures/issues/146).